### PR TITLE
chore: trigger release on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: Release to npm
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
 
 jobs:
   release:
@@ -20,7 +19,7 @@ jobs:
 
       - run: bun install
       - run: bun run typecheck
-      - run: bun test
+      - run: bun test $(find src -name '*.test.*' ! -name '*.integration.test.*')
       - run: bun run build
 
       - name: Release


### PR DESCRIPTION
## Summary

- Change release workflow trigger from `v*` tags to pushes on `main`
- Exclude integration tests from release workflow

semantic-release will now run automatically on every push to main, analyze conventional commits, and publish to npm only when there are releasable changes (`feat:`, `fix:`).

## Test plan

- [ ] Merge a `feat:` or `fix:` commit to main and verify a release + npm publish is triggered