### PR TITLE
docs: add AUR and Homebrew install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ Requires Node.js >= 18.18.0.
   brew install westpoint-io/dustoff/dustoff
   ```
 
-- **On [Arch Linux](https://aur.archlinux.org/packages/dustoff)** (AUR)
+- **On [Arch Linux](https://aur.archlinux.org/packages/dustoff)** (AUR) — requires an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers)
 
   ```bash
   yay -S dustoff
+  # or
+  paru -S dustoff
   ```
 
 ### CLI Options


### PR DESCRIPTION
## Summary
- Add AUR and Homebrew version badges to README header
- Add Homebrew and Arch Linux (AUR) install instructions alongside existing npm/bun methods

## Context
- AUR package: https://aur.archlinux.org/packages/dustoff
- Homebrew tap: https://github.com/westpoint-io/homebrew-dustoff