### PR TITLE
release: 1.1.0 — grouped file-based artifact scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## 🧹 What It Does
 
-Scan your filesystem for JavaScript/TypeScript build artifacts — `node_modules`, `.next`, `dist`, `.cache`, `coverage`, `.turbo`, and [30+ more](#detected-artifacts) — then interactively browse, sort, select, and safely delete them to reclaim disk space.
+Scan your filesystem for JavaScript/TypeScript build artifacts — directories like `node_modules`, `.next`, `dist`, `.cache`, `coverage`, `.turbo`, and files like `.tsbuildinfo`, `.eslintcache`, heap snapshots, debug logs, and [more](#detected-artifacts) — then interactively browse, sort, select, and safely delete them to reclaim disk space.
 
 ## 🚀 Installation
 
@@ -98,9 +98,13 @@ Press `/` to search — instantly filter artifacts by path. Press `f` to open th
   <img src="assets/features/search_filter.gif" alt="Searching and filtering artifacts" width="800" />
 </p>
 
+### File Artifact Scanning
+
+dustoff detects individual build artifact files (`.tsbuildinfo`, `.eslintcache`, debug logs, heap snapshots, etc.) and groups them by type into collapsible rows. Expand with `Enter` to see individual files, or select the whole group with `Space`.
+
 ### Directory Grouping
 
-Press `x` to group artifacts by parent directory. Collapse and expand groups with `Enter` or arrow keys. Select an entire group at once with `Space` on the group header.
+Press `x` to group artifacts by parent directory. Collapse and expand groups with `Enter` or arrow keys. Select an entire group at once with `Space` on the group header. File groups nest inside their parent directory groups.
 
 <p align="center">
   <img src="assets/features/grouping.gif" alt="Directory grouping" width="800" />
@@ -185,19 +189,32 @@ Cycle through themes with `t` during a session. Your preference is saved to `~/.
 
 ## 🔍 Detected Artifacts
 
-dustoff scans for these directories:
+### Directories
 
 | Category | Directories |
 |----------|-------------|
 | **Package managers** | `node_modules`, `.npm`, `.pnpm-store` |
 | **Framework builds** | `.next`, `.nuxt`, `.angular`, `.svelte-kit`, `.vite`, `.turbo`, `.nx` |
 | **Bundler caches** | `.parcel-cache`, `.rpt2_cache`, `.esbuild`, `.rollup.cache`, `.cache` |
-| **Linter/formatter** | `.eslintcache`, `.stylelintcache` |
 | **Transpiler** | `.swc` |
 | **Test/coverage** | `coverage`, `.nyc_output`, `.jest` |
 | **Docs/storybook** | `storybook-static`, `gatsby_cache`, `.docusaurus` |
+| **Serverless** | `.serverless` |
 | **Runtime** | `deno_cache` |
 | **Build outputs** | `dist`, `build`, `.output` |
+
+### Files
+
+Files are grouped by type into collapsible rows.
+
+| Category | Files |
+|----------|-------|
+| **Build/compiler** | `.tsbuildinfo` |
+| **Linter/formatter caches** | `.eslintcache`, `.stylelintcache` |
+| **Yarn PnP** | `.pnp.cjs`, `.pnp.loader.mjs` |
+| **Package manager logs** | `npm-debug.log*`, `yarn-error.log*`, `yarn-debug.log*`, `pnpm-debug.log*`, `.pnpm-debug.log*`, `lerna-debug.log*` |
+| **Profiling/diagnostics** | `*.heapsnapshot`, `*.cpuprofile`, `*.heapprofile` |
+| **Package archives** | `*.tgz` |
 
 ## 🤝 Contributing
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -136,18 +136,23 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
     return displayItems[state.cursorIndex];
   };
 
-  // Skip cursor past section separators
+  // Skip cursor past section separators — track previous index to determine direction
+  const prevCursorRef = useRef(state.cursorIndex);
   useEffect(() => {
-    if (state.groupingEnabled) return;
+    if (state.groupingEnabled) {
+      prevCursorRef.current = state.cursorIndex;
+      return;
+    }
     const item = displayItems[state.cursorIndex];
     if (item?.kind === 'section-separator') {
-      // Try moving down first, then up
-      if (state.cursorIndex + 1 < displayItems.length) {
-        dispatch({ type: 'SET_CURSOR', index: state.cursorIndex + 1 });
-      } else if (state.cursorIndex > 0) {
+      const movingUp = state.cursorIndex < prevCursorRef.current;
+      if (movingUp && state.cursorIndex > 0) {
         dispatch({ type: 'SET_CURSOR', index: state.cursorIndex - 1 });
+      } else if (state.cursorIndex + 1 < displayItems.length) {
+        dispatch({ type: 'SET_CURSOR', index: state.cursorIndex + 1 });
       }
     }
+    prevCursorRef.current = state.cursorIndex;
   }, [state.cursorIndex, state.groupingEnabled, displayItems]);
 
   useInput((input, key) => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -136,45 +136,24 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
     return displayItems[state.cursorIndex];
   };
 
-  // Skip cursor past section separators — track previous index to determine direction
-  const prevCursorRef = useRef(state.cursorIndex);
-  useEffect(() => {
-    if (state.groupingEnabled) {
-      prevCursorRef.current = state.cursorIndex;
-      return;
+  // Helper: find the next valid cursor index, skipping section separators
+  const skipSeparators = (index: number, direction: 'up' | 'down'): number => {
+    if (state.groupingEnabled || !displayItems[index]) return index;
+    if (displayItems[index]?.kind !== 'section-separator') return index;
+    const step = direction === 'up' ? -1 : 1;
+    let i = index + step;
+    while (i >= 0 && i < displayItems.length) {
+      if (displayItems[i]?.kind !== 'section-separator') return i;
+      i += step;
     }
-    const item = displayItems[state.cursorIndex];
-    if (item?.kind === 'section-separator') {
-      const movingUp = state.cursorIndex < prevCursorRef.current;
-      // Find nearest non-separator in the preferred direction
-      if (movingUp) {
-        // Look upward for a non-separator, fall back to downward
-        let target = -1;
-        for (let i = state.cursorIndex - 1; i >= 0; i--) {
-          if (displayItems[i]?.kind !== 'section-separator') { target = i; break; }
-        }
-        if (target === -1) {
-          for (let i = state.cursorIndex + 1; i < displayItems.length; i++) {
-            if (displayItems[i]?.kind !== 'section-separator') { target = i; break; }
-          }
-        }
-        if (target !== -1) dispatch({ type: 'SET_CURSOR', index: target });
-      } else {
-        // Look downward for a non-separator, fall back to upward
-        let target = -1;
-        for (let i = state.cursorIndex + 1; i < displayItems.length; i++) {
-          if (displayItems[i]?.kind !== 'section-separator') { target = i; break; }
-        }
-        if (target === -1) {
-          for (let i = state.cursorIndex - 1; i >= 0; i--) {
-            if (displayItems[i]?.kind !== 'section-separator') { target = i; break; }
-          }
-        }
-        if (target !== -1) dispatch({ type: 'SET_CURSOR', index: target });
-      }
+    // Nothing found in preferred direction, search opposite
+    i = index - step;
+    while (i >= 0 && i < displayItems.length) {
+      if (displayItems[i]?.kind !== 'section-separator') return i;
+      i -= step;
     }
-    prevCursorRef.current = state.cursorIndex;
-  }, [state.cursorIndex, state.groupingEnabled, displayItems]);
+    return index; // fallback: stay put
+  };
 
   useInput((input, key) => {
     // Confirm delete dialog — navigate between Yes/Cancel
@@ -321,13 +300,19 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
       ? flatItems.length
       : displayItems.length;
     if (key.upArrow || input === 'k') {
-      dispatch({ type: 'CURSOR_UP' });
+      const next = skipSeparators(Math.max(0, state.cursorIndex - 1), 'up');
+      dispatch({ type: 'SET_CURSOR', index: next });
     } else if (key.downArrow || input === 'j') {
-      dispatch({ type: 'CURSOR_DOWN', itemCount: effectiveItemCount });
+      const max = effectiveItemCount - 1;
+      const next = skipSeparators(Math.min(max, state.cursorIndex + 1), 'down');
+      dispatch({ type: 'SET_CURSOR', index: next });
     } else if (key.pageUp) {
-      dispatch({ type: 'CURSOR_PAGE_UP', visibleCount, itemCount: effectiveItemCount });
+      const next = skipSeparators(Math.max(0, state.cursorIndex - visibleCount), 'up');
+      dispatch({ type: 'SET_CURSOR', index: next });
     } else if (key.pageDown) {
-      dispatch({ type: 'CURSOR_PAGE_DOWN', visibleCount, itemCount: effectiveItemCount });
+      const max = effectiveItemCount - 1;
+      const next = skipSeparators(Math.min(max, state.cursorIndex + visibleCount), 'down');
+      dispatch({ type: 'SET_CURSOR', index: next });
     } else if (key.tab) {
       dispatch({ type: 'DETAIL_TOGGLE' });
     } else if (key.return) {
@@ -439,9 +424,9 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
       dispatch({ type: 'CYCLE_THEME' });
       // Flash will be set via the effect below
     } else if (input === 'g' && !key.shift) {
-      dispatch({ type: 'CURSOR_HOME' });
+      dispatch({ type: 'SET_CURSOR', index: skipSeparators(0, 'down') });
     } else if (input === 'G') {
-      dispatch({ type: 'CURSOR_END', itemCount: effectiveItemCount });
+      dispatch({ type: 'SET_CURSOR', index: skipSeparators(effectiveItemCount - 1, 'up') });
     } else if (input === 'x') {
       dispatch({ type: 'TOGGLE_GROUPING' });
     } else if (input === '-' && state.detailVisible) {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -103,6 +103,19 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
     [state.artifacts, state.sortKey, state.sortDir, state.searchQuery, state.typeFilter, state.expandedFileTypes],
   );
 
+  // Ensure cursor doesn't sit on a separator (e.g., initial state where cursor=0 is the "Directories" header)
+  useEffect(() => {
+    if (state.groupingEnabled || displayItems.length === 0) return;
+    if (displayItems[state.cursorIndex]?.kind === 'section-separator') {
+      for (let i = state.cursorIndex + 1; i < displayItems.length; i++) {
+        if (displayItems[i]?.kind !== 'section-separator') {
+          dispatch({ type: 'SET_CURSOR', index: i });
+          return;
+        }
+      }
+    }
+  }, [state.scanStatus]);
+
   // Compute flat items for grouping mode
   const flatItems: FlatItem[] = useMemo(() => {
     if (!state.groupingEnabled) return [];

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -146,10 +146,31 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
     const item = displayItems[state.cursorIndex];
     if (item?.kind === 'section-separator') {
       const movingUp = state.cursorIndex < prevCursorRef.current;
-      if (movingUp && state.cursorIndex > 0) {
-        dispatch({ type: 'SET_CURSOR', index: state.cursorIndex - 1 });
-      } else if (state.cursorIndex + 1 < displayItems.length) {
-        dispatch({ type: 'SET_CURSOR', index: state.cursorIndex + 1 });
+      // Find nearest non-separator in the preferred direction
+      if (movingUp) {
+        // Look upward for a non-separator, fall back to downward
+        let target = -1;
+        for (let i = state.cursorIndex - 1; i >= 0; i--) {
+          if (displayItems[i]?.kind !== 'section-separator') { target = i; break; }
+        }
+        if (target === -1) {
+          for (let i = state.cursorIndex + 1; i < displayItems.length; i++) {
+            if (displayItems[i]?.kind !== 'section-separator') { target = i; break; }
+          }
+        }
+        if (target !== -1) dispatch({ type: 'SET_CURSOR', index: target });
+      } else {
+        // Look downward for a non-separator, fall back to upward
+        let target = -1;
+        for (let i = state.cursorIndex + 1; i < displayItems.length; i++) {
+          if (displayItems[i]?.kind !== 'section-separator') { target = i; break; }
+        }
+        if (target === -1) {
+          for (let i = state.cursorIndex - 1; i >= 0; i--) {
+            if (displayItems[i]?.kind !== 'section-separator') { target = i; break; }
+          }
+        }
+        if (target !== -1) dispatch({ type: 'SET_CURSOR', index: target });
       }
     }
     prevCursorRef.current = state.cursorIndex;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,7 +13,8 @@ import { TypeFilter } from '../features/browse/TypeFilter.js';
 import { LOGO, getThemeByName } from '../shared/themes.js';
 import { ThemeProvider } from '../shared/ThemeContext.js';
 import { formatBytes, truncatePath } from '../shared/formatters.js';
-import { reducer, initialState, getSortedArtifacts } from './reducer.js';
+import { reducer, initialState, getSortedArtifacts, getDisplayItems } from './reducer.js';
+import type { DisplayItem } from './reducer.js';
 import { loadThemeName, saveThemeName } from '../shared/config.js';
 import { groupArtifacts, flattenGroups } from '../features/browse/grouping.js';
 import type { FlatItem } from '../features/browse/grouping.js';
@@ -97,6 +98,11 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
     [state.artifacts, state.sortKey, state.sortDir, state.searchQuery, state.typeFilter],
   );
 
+  const displayItems = useMemo(
+    () => getDisplayItems(state),
+    [state.artifacts, state.sortKey, state.sortDir, state.searchQuery, state.typeFilter, state.expandedFileTypes],
+  );
+
   // Compute flat items for grouping mode
   const flatItems: FlatItem[] = useMemo(() => {
     if (!state.groupingEnabled) return [];
@@ -123,6 +129,11 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
   const getCursorFlatItem = (): FlatItem | undefined => {
     if (!state.groupingEnabled || flatItems.length === 0) return undefined;
     return flatItems[state.cursorIndex];
+  };
+
+  const getCursorDisplayItem = (): DisplayItem | undefined => {
+    if (state.groupingEnabled) return undefined;
+    return displayItems[state.cursorIndex];
   };
 
   useInput((input, key) => {
@@ -250,7 +261,9 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
       return;
     }
 
-    const effectiveItemCount = state.groupingEnabled && flatItems.length > 0 ? flatItems.length : sortedArtifacts.length;
+    const effectiveItemCount = state.groupingEnabled && flatItems.length > 0
+      ? flatItems.length
+      : displayItems.length;
     if (key.upArrow || input === 'k') {
       dispatch({ type: 'CURSOR_UP' });
     } else if (key.downArrow || input === 'j') {
@@ -261,10 +274,17 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
       dispatch({ type: 'CURSOR_PAGE_DOWN', visibleCount, itemCount: effectiveItemCount });
     } else if (key.tab) {
       dispatch({ type: 'DETAIL_TOGGLE' });
-    } else if (key.return && state.groupingEnabled) {
-      const item = getCursorFlatItem();
-      if (item?.kind === 'group-header') {
-        dispatch({ type: 'TOGGLE_GROUP_COLLAPSE', key: item.group.key });
+    } else if (key.return) {
+      if (state.groupingEnabled) {
+        const item = getCursorFlatItem();
+        if (item?.kind === 'group-header') {
+          dispatch({ type: 'TOGGLE_GROUP_COLLAPSE', key: item.group.key });
+        }
+      } else {
+        const item = getCursorDisplayItem();
+        if (item?.kind === 'file-group') {
+          dispatch({ type: 'TOGGLE_FILE_TYPE_EXPAND', fileType: item.group.type });
+        }
       }
     } else if (key.rightArrow && state.groupingEnabled) {
       const item = getCursorFlatItem();
@@ -275,6 +295,16 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
       const item = getCursorFlatItem();
       if (item?.kind === 'group-header' && !state.collapsedGroups.has(item.group.key)) {
         dispatch({ type: 'TOGGLE_GROUP_COLLAPSE', key: item.group.key });
+      }
+    } else if (key.rightArrow && !state.groupingEnabled) {
+      const item = getCursorDisplayItem();
+      if (item?.kind === 'file-group' && !state.expandedFileTypes.has(item.group.type)) {
+        dispatch({ type: 'TOGGLE_FILE_TYPE_EXPAND', fileType: item.group.type });
+      }
+    } else if (key.leftArrow && !state.groupingEnabled) {
+      const item = getCursorDisplayItem();
+      if (item?.kind === 'file-group' && state.expandedFileTypes.has(item.group.type)) {
+        dispatch({ type: 'TOGGLE_FILE_TYPE_EXPAND', fileType: item.group.type });
       }
     } else if (input === ' ' && key.shift && state.selectionAnchor !== null) {
       const start = Math.min(state.selectionAnchor, state.cursorIndex);
@@ -297,9 +327,14 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
           dispatch({ type: 'TOGGLE_SELECT', path: item.artifact.path });
         }
       } else {
-        const artifact = sortedArtifacts[state.cursorIndex];
-        if (artifact) {
-          dispatch({ type: 'TOGGLE_SELECT', path: artifact.path });
+        const item = getCursorDisplayItem();
+        if (item?.kind === 'file-group') {
+          dispatch({
+            type: 'TOGGLE_FILE_GROUP_SELECT',
+            paths: item.group.files.map((f) => f.path),
+          });
+        } else if (item?.kind === 'directory' || item?.kind === 'file') {
+          dispatch({ type: 'TOGGLE_SELECT', path: item.artifact.path });
         }
       }
     } else if (input === 'a') {
@@ -380,8 +415,10 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
       if (item?.kind === 'artifact') return item.artifact;
       return undefined;
     }
-    return sortedArtifacts[state.cursorIndex];
-  }, [state.groupingEnabled, flatItems, sortedArtifacts, state.cursorIndex]);
+    const dItem = displayItems[state.cursorIndex];
+    if (dItem?.kind === 'directory' || dItem?.kind === 'file') return dItem.artifact;
+    return undefined;
+  }, [state.groupingEnabled, flatItems, displayItems, state.cursorIndex]);
 
   // Animated progress bar position (indeterminate bounce)
   const [barTick, setBarTick] = useState(0);
@@ -503,6 +540,7 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
                 detailWidth={detailWidth}
                 onVisibleCountChange={setVisibleCount}
                 flatItems={state.groupingEnabled ? flatItems : undefined}
+                displayItems={state.groupingEnabled ? undefined : displayItems}
                 searchQuery={state.searchQuery}
                 isSearchMode={state.isSearchMode}
                 searchResultCount={sortedArtifacts.length}
@@ -544,7 +582,7 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
           scanDurationMs={state.scanDurationMs}
           directoriesScanned={state.directoriesScanned}
           cursorIndex={state.cursorIndex}
-          totalArtifacts={state.groupingEnabled && flatItems.length > 0 ? flatItems.length : sortedArtifacts.length}
+          totalArtifacts={state.groupingEnabled && flatItems.length > 0 ? flatItems.length : displayItems.length}
         />
 
         {/* Shortcut bar — replaced by flash/toast when active */}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -107,8 +107,8 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
   const flatItems: FlatItem[] = useMemo(() => {
     if (!state.groupingEnabled) return [];
     const groups = groupArtifacts(sortedArtifacts, rootPath);
-    return flattenGroups(groups, state.collapsedGroups);
-  }, [state.groupingEnabled, sortedArtifacts, rootPath, state.collapsedGroups]);
+    return flattenGroups(groups, state.collapsedGroups, state.expandedFileTypes);
+  }, [state.groupingEnabled, sortedArtifacts, rootPath, state.collapsedGroups, state.expandedFileTypes]);
 
   // Compute available types for type filter
   const availableTypes = useMemo(() => {
@@ -275,7 +275,8 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
       let paths: string[];
       if (state.groupingEnabled && flatItems.length > 0) {
         paths = flatItems.slice(start, end + 1)
-          .filter((item): item is Extract<typeof item, { kind: 'artifact' }> => item.kind === 'artifact')
+          .filter((item): item is Extract<typeof item, { kind: 'artifact' }> | Extract<typeof item, { kind: 'file-nested' }> =>
+            item.kind === 'artifact' || item.kind === 'file-nested')
           .map((item) => item.artifact.path);
       } else {
         paths = displayItems.slice(start, end + 1)
@@ -308,6 +309,8 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
         const item = getCursorFlatItem();
         if (item?.kind === 'group-header') {
           dispatch({ type: 'TOGGLE_GROUP_COLLAPSE', key: item.group.key });
+        } else if (item?.kind === 'file-group-nested') {
+          dispatch({ type: 'TOGGLE_FILE_TYPE_EXPAND', fileType: item.type });
         }
       } else {
         const item = getCursorDisplayItem();
@@ -319,11 +322,15 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
       const item = getCursorFlatItem();
       if (item?.kind === 'group-header' && state.collapsedGroups.has(item.group.key)) {
         dispatch({ type: 'TOGGLE_GROUP_COLLAPSE', key: item.group.key });
+      } else if (item?.kind === 'file-group-nested' && !state.expandedFileTypes.has(item.type)) {
+        dispatch({ type: 'TOGGLE_FILE_TYPE_EXPAND', fileType: item.type });
       }
     } else if (key.leftArrow && state.groupingEnabled) {
       const item = getCursorFlatItem();
       if (item?.kind === 'group-header' && !state.collapsedGroups.has(item.group.key)) {
         dispatch({ type: 'TOGGLE_GROUP_COLLAPSE', key: item.group.key });
+      } else if (item?.kind === 'file-group-nested' && state.expandedFileTypes.has(item.type)) {
+        dispatch({ type: 'TOGGLE_FILE_TYPE_EXPAND', fileType: item.type });
       }
     } else if (key.rightArrow && !state.groupingEnabled) {
       const item = getCursorDisplayItem();
@@ -341,7 +348,8 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
       let paths: string[];
       if (state.groupingEnabled && flatItems.length > 0) {
         paths = flatItems.slice(start, end + 1)
-          .filter((item): item is Extract<typeof item, { kind: 'artifact' }> => item.kind === 'artifact')
+          .filter((item): item is Extract<typeof item, { kind: 'artifact' }> | Extract<typeof item, { kind: 'file-nested' }> =>
+            item.kind === 'artifact' || item.kind === 'file-nested')
           .map((item) => item.artifact.path);
       } else {
         paths = displayItems.slice(start, end + 1)
@@ -363,6 +371,13 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
             dispatch({ type: 'SELECT_PATHS', paths });
           }
         } else if (item?.kind === 'artifact') {
+          dispatch({ type: 'TOGGLE_SELECT', path: item.artifact.path });
+        } else if (item?.kind === 'file-group-nested') {
+          dispatch({
+            type: 'TOGGLE_FILE_GROUP_SELECT',
+            paths: item.files.map((f) => f.path),
+          });
+        } else if (item?.kind === 'file-nested') {
           dispatch({ type: 'TOGGLE_SELECT', path: item.artifact.path });
         }
       } else {
@@ -451,7 +466,7 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
   const cursorArtifact = useMemo(() => {
     if (state.groupingEnabled && flatItems.length > 0) {
       const item = flatItems[state.cursorIndex];
-      if (item?.kind === 'artifact') return item.artifact;
+      if (item?.kind === 'artifact' || item?.kind === 'file-nested') return item.artifact;
       return undefined;
     }
     const dItem = displayItems[state.cursorIndex];

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -136,6 +136,20 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
     return displayItems[state.cursorIndex];
   };
 
+  // Skip cursor past section separators
+  useEffect(() => {
+    if (state.groupingEnabled) return;
+    const item = displayItems[state.cursorIndex];
+    if (item?.kind === 'section-separator') {
+      // Try moving down first, then up
+      if (state.cursorIndex + 1 < displayItems.length) {
+        dispatch({ type: 'SET_CURSOR', index: state.cursorIndex + 1 });
+      } else if (state.cursorIndex > 0) {
+        dispatch({ type: 'SET_CURSOR', index: state.cursorIndex - 1 });
+      }
+    }
+  }, [state.cursorIndex, state.groupingEnabled, displayItems]);
+
   useInput((input, key) => {
     // Confirm delete dialog — navigate between Yes/Cancel
     if (state.viewMode === 'confirm-delete') {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -103,6 +103,11 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
     [state.artifacts, state.sortKey, state.sortDir, state.searchQuery, state.typeFilter, state.expandedFileTypes],
   );
 
+  const selectableDisplayCount = useMemo(
+    () => displayItems.filter((i) => i.kind !== 'section-separator').length,
+    [displayItems],
+  );
+
   // Ensure cursor doesn't sit on a separator (e.g., initial state where cursor=0 is the "Directories" header)
   useEffect(() => {
     if (state.groupingEnabled || displayItems.length === 0) return;
@@ -114,7 +119,7 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
         }
       }
     }
-  }, [state.scanStatus]);
+  }, [state.scanStatus, state.cursorIndex, state.groupingEnabled, displayItems]);
 
   // Compute flat items for grouping mode
   const flatItems: FlatItem[] = useMemo(() => {
@@ -151,21 +156,22 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
 
   // Helper: find the next valid cursor index, skipping section separators
   const skipSeparators = (index: number, direction: 'up' | 'down'): number => {
-    if (state.groupingEnabled || !displayItems[index]) return index;
-    if (displayItems[index]?.kind !== 'section-separator') return index;
+    if (state.groupingEnabled || displayItems.length === 0) return Math.max(0, index);
+    const clamped = Math.max(0, Math.min(index, displayItems.length - 1));
+    if (displayItems[clamped]?.kind !== 'section-separator') return clamped;
     const step = direction === 'up' ? -1 : 1;
-    let i = index + step;
+    let i = clamped + step;
     while (i >= 0 && i < displayItems.length) {
       if (displayItems[i]?.kind !== 'section-separator') return i;
       i += step;
     }
     // Nothing found in preferred direction, search opposite
-    i = index - step;
+    i = clamped - step;
     while (i >= 0 && i < displayItems.length) {
       if (displayItems[i]?.kind !== 'section-separator') return i;
       i -= step;
     }
-    return index; // fallback: stay put
+    return clamped; // fallback: stay put
   };
 
   useInput((input, key) => {
@@ -312,20 +318,21 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
     const effectiveItemCount = state.groupingEnabled && flatItems.length > 0
       ? flatItems.length
       : displayItems.length;
+    if (effectiveItemCount === 0) return;
     if (key.upArrow || input === 'k') {
       const next = skipSeparators(Math.max(0, state.cursorIndex - 1), 'up');
-      dispatch({ type: 'SET_CURSOR', index: next });
+      dispatch({ type: 'CURSOR_MOVE', index: next });
     } else if (key.downArrow || input === 'j') {
       const max = effectiveItemCount - 1;
       const next = skipSeparators(Math.min(max, state.cursorIndex + 1), 'down');
-      dispatch({ type: 'SET_CURSOR', index: next });
+      dispatch({ type: 'CURSOR_MOVE', index: next });
     } else if (key.pageUp) {
       const next = skipSeparators(Math.max(0, state.cursorIndex - visibleCount), 'up');
-      dispatch({ type: 'SET_CURSOR', index: next });
+      dispatch({ type: 'CURSOR_MOVE', index: next });
     } else if (key.pageDown) {
       const max = effectiveItemCount - 1;
       const next = skipSeparators(Math.min(max, state.cursorIndex + visibleCount), 'down');
-      dispatch({ type: 'SET_CURSOR', index: next });
+      dispatch({ type: 'CURSOR_MOVE', index: next });
     } else if (key.tab) {
       dispatch({ type: 'DETAIL_TOGGLE' });
     } else if (key.return) {
@@ -437,9 +444,9 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
       dispatch({ type: 'CYCLE_THEME' });
       // Flash will be set via the effect below
     } else if (input === 'g' && !key.shift) {
-      dispatch({ type: 'SET_CURSOR', index: skipSeparators(0, 'down') });
+      dispatch({ type: 'CURSOR_MOVE', index: skipSeparators(0, 'down') });
     } else if (input === 'G') {
-      dispatch({ type: 'SET_CURSOR', index: skipSeparators(effectiveItemCount - 1, 'up') });
+      dispatch({ type: 'CURSOR_MOVE', index: skipSeparators(effectiveItemCount - 1, 'up') });
     } else if (input === 'x') {
       dispatch({ type: 'TOGGLE_GROUPING' });
     } else if (input === '-' && state.detailVisible) {
@@ -660,7 +667,7 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
           scanDurationMs={state.scanDurationMs}
           directoriesScanned={state.directoriesScanned}
           cursorIndex={state.cursorIndex}
-          totalArtifacts={state.groupingEnabled && flatItems.length > 0 ? flatItems.length : displayItems.length}
+          totalArtifacts={state.groupingEnabled && flatItems.length > 0 ? flatItems.length : selectableDisplayCount}
         />
 
         {/* Shortcut bar — replaced by flash/toast when active */}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -249,12 +249,27 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
 
     if (rangeUp || rangeDown) {
       const anchor = state.selectionAnchor ?? state.cursorIndex;
+      const maxIndex = state.groupingEnabled && flatItems.length > 0
+        ? flatItems.length - 1
+        : displayItems.length - 1;
       const newCursor = rangeUp
         ? Math.max(0, state.cursorIndex - 1)
-        : Math.min(sortedArtifacts.length - 1, state.cursorIndex + 1);
+        : Math.min(maxIndex, state.cursorIndex + 1);
       const start = Math.min(anchor, newCursor);
       const end = Math.max(anchor, newCursor);
-      const paths = sortedArtifacts.slice(start, end + 1).map((a) => a.path);
+
+      let paths: string[];
+      if (state.groupingEnabled && flatItems.length > 0) {
+        paths = flatItems.slice(start, end + 1)
+          .filter((item): item is Extract<typeof item, { kind: 'artifact' }> => item.kind === 'artifact')
+          .map((item) => item.artifact.path);
+      } else {
+        paths = displayItems.slice(start, end + 1)
+          .filter((item): item is Extract<DisplayItem, { kind: 'directory' | 'file' }> =>
+            item.kind === 'directory' || item.kind === 'file')
+          .map((item) => item.artifact.path);
+      }
+
       dispatch({ type: 'SET_RANGE_SELECTION', paths });
       dispatch({ type: 'SET_SELECTION_ANCHOR', anchor });
       dispatch({ type: 'SET_CURSOR', index: newCursor });
@@ -309,7 +324,17 @@ export default function App({ rootPath = process.cwd(), exclude, targets, verbos
     } else if (input === ' ' && key.shift && state.selectionAnchor !== null) {
       const start = Math.min(state.selectionAnchor, state.cursorIndex);
       const end = Math.max(state.selectionAnchor, state.cursorIndex);
-      const paths = sortedArtifacts.slice(start, end + 1).map((a) => a.path);
+      let paths: string[];
+      if (state.groupingEnabled && flatItems.length > 0) {
+        paths = flatItems.slice(start, end + 1)
+          .filter((item): item is Extract<typeof item, { kind: 'artifact' }> => item.kind === 'artifact')
+          .map((item) => item.artifact.path);
+      } else {
+        paths = displayItems.slice(start, end + 1)
+          .filter((item): item is Extract<DisplayItem, { kind: 'directory' | 'file' }> =>
+            item.kind === 'directory' || item.kind === 'file')
+          .map((item) => item.artifact.path);
+      }
       dispatch({ type: 'SELECT_PATHS', paths });
       return;
     } else if (input === ' ') {

--- a/src/app/reducer.test.ts
+++ b/src/app/reducer.test.ts
@@ -45,8 +45,8 @@ describe('sizeColor', () => {
 describe('reducer — selection', () => {
   const baseState: AppState = {
     artifacts: [
-      { path: '/a/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: Date.now() },
-      { path: '/b/dist', type: 'dist', sizeBytes: 200, mtimeMs: Date.now() },
+      { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: Date.now() },
+      { path: '/b/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: Date.now() },
     ],
     scanStatus: 'complete',
     scanDurationMs: 100,
@@ -131,9 +131,9 @@ describe('reducer — selection', () => {
 describe('CURSOR_HOME action', () => {
   const baseState: AppState = {
     artifacts: [
-      { path: '/a/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: Date.now() },
-      { path: '/b/dist', type: 'dist', sizeBytes: 200, mtimeMs: Date.now() },
-      { path: '/c/.next', type: '.next', sizeBytes: 300, mtimeMs: Date.now() },
+      { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: Date.now() },
+      { path: '/b/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: Date.now() },
+      { path: '/c/.next', type: '.next', kind: 'directory', sizeBytes: 300, mtimeMs: Date.now() },
     ],
     scanStatus: 'complete',
     scanDurationMs: 100,
@@ -175,9 +175,9 @@ describe('CURSOR_HOME action', () => {
 describe('CURSOR_END action', () => {
   const baseState: AppState = {
     artifacts: [
-      { path: '/a/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: Date.now() },
-      { path: '/b/dist', type: 'dist', sizeBytes: 200, mtimeMs: Date.now() },
-      { path: '/c/.next', type: '.next', sizeBytes: 300, mtimeMs: Date.now() },
+      { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: Date.now() },
+      { path: '/b/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: Date.now() },
+      { path: '/c/.next', type: '.next', kind: 'directory', sizeBytes: 300, mtimeMs: Date.now() },
     ],
     scanStatus: 'complete',
     scanDurationMs: 100,
@@ -319,9 +319,9 @@ describe('SET_SEARCH_QUERY action', () => {
 describe('DELETE_COMPLETE sets toast', () => {
   const baseState: AppState = {
     artifacts: [
-      { path: '/a/node_modules', type: 'node_modules', sizeBytes: 500, mtimeMs: Date.now() },
-      { path: '/b/dist', type: 'dist', sizeBytes: 300, mtimeMs: Date.now() },
-      { path: '/c/.next', type: '.next', sizeBytes: 200, mtimeMs: Date.now() },
+      { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 500, mtimeMs: Date.now() },
+      { path: '/b/dist', type: 'dist', kind: 'directory', sizeBytes: 300, mtimeMs: Date.now() },
+      { path: '/c/.next', type: '.next', kind: 'directory', sizeBytes: 200, mtimeMs: Date.now() },
     ],
     scanStatus: 'complete',
     scanDurationMs: 100,
@@ -368,7 +368,7 @@ describe('DELETE_COMPLETE sets toast', () => {
     const stateWithNull: AppState = {
       ...baseState,
       artifacts: [
-        { path: '/a/node_modules', type: 'node_modules', sizeBytes: null, mtimeMs: Date.now() },
+        { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: null, mtimeMs: Date.now() },
       ],
     };
     const next = reducer(stateWithNull, {
@@ -449,9 +449,9 @@ describe('getSortedArtifacts with search filter', () => {
 
   it('returns all artifacts when searchQuery is empty', () => {
     const artifacts = [
-      { path: '/a/node_modules', type: 'dir' as const, sizeBytes: 100, mtimeMs: 1 },
-      { path: '/b/dist', type: 'dir' as const, sizeBytes: 200, mtimeMs: 2 },
-      { path: '/c/build', type: 'dir' as const, sizeBytes: 300, mtimeMs: 3 },
+      { path: '/a/node_modules', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 100, mtimeMs: 1 },
+      { path: '/b/dist', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 200, mtimeMs: 2 },
+      { path: '/c/build', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 300, mtimeMs: 3 },
     ];
     const state = { ...baseState, artifacts, searchQuery: '' };
     const result = getSortedArtifacts(state);
@@ -464,9 +464,9 @@ describe('getSortedArtifacts with search filter', () => {
 
   it('filters artifacts by path substring (case-insensitive)', () => {
     const artifacts = [
-      { path: '/a/node_modules', type: 'dir' as const, sizeBytes: 100, mtimeMs: 1 },
-      { path: '/b/dist', type: 'dir' as const, sizeBytes: 200, mtimeMs: 2 },
-      { path: '/c/NODE_MODULES', type: 'dir' as const, sizeBytes: 300, mtimeMs: 3 },
+      { path: '/a/node_modules', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 100, mtimeMs: 1 },
+      { path: '/b/dist', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 200, mtimeMs: 2 },
+      { path: '/c/NODE_MODULES', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 300, mtimeMs: 3 },
     ];
     const state = { ...baseState, artifacts, searchQuery: 'node' };
     const result = getSortedArtifacts(state);
@@ -478,8 +478,8 @@ describe('getSortedArtifacts with search filter', () => {
 
   it('returns empty array when no artifacts match filter', () => {
     const artifacts = [
-      { path: '/a/node_modules', type: 'dir' as const, sizeBytes: 100, mtimeMs: 1 },
-      { path: '/b/dist', type: 'dir' as const, sizeBytes: 200, mtimeMs: 2 },
+      { path: '/a/node_modules', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 100, mtimeMs: 1 },
+      { path: '/b/dist', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 200, mtimeMs: 2 },
     ];
     const state = { ...baseState, artifacts, searchQuery: 'nomatch' };
     const result = getSortedArtifacts(state);
@@ -488,9 +488,9 @@ describe('getSortedArtifacts with search filter', () => {
 
   it('preserves sort order when filtering', () => {
     const artifacts = [
-      { path: '/a/node_modules', type: 'dir' as const, sizeBytes: 300, mtimeMs: 1 },
-      { path: '/b/node_modules2', type: 'dir' as const, sizeBytes: 100, mtimeMs: 2 },
-      { path: '/c/dist', type: 'dir' as const, sizeBytes: 200, mtimeMs: 3 },
+      { path: '/a/node_modules', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 300, mtimeMs: 1 },
+      { path: '/b/node_modules2', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 100, mtimeMs: 2 },
+      { path: '/c/dist', type: 'dir' as const, kind: 'directory' as const, sizeBytes: 200, mtimeMs: 3 },
     ];
     const state = {
       ...baseState,
@@ -511,7 +511,7 @@ describe('getSortedArtifacts with search filter', () => {
 describe('TOGGLE_GROUPING action', () => {
   const baseState: AppState = {
     artifacts: [
-      { path: '/a/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: Date.now() },
+      { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: Date.now() },
     ],
     scanStatus: 'complete',
     scanDurationMs: 100,
@@ -604,9 +604,9 @@ describe('TOGGLE_GROUP_COLLAPSE action', () => {
 describe('SELECT_PATHS action', () => {
   const baseState: AppState = {
     artifacts: [
-      { path: '/a/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: Date.now() },
-      { path: '/a/dist', type: 'dist', sizeBytes: 200, mtimeMs: Date.now() },
-      { path: '/b/.next', type: '.next', sizeBytes: 300, mtimeMs: Date.now() },
+      { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: Date.now() },
+      { path: '/a/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: Date.now() },
+      { path: '/b/.next', type: '.next', kind: 'directory', sizeBytes: 300, mtimeMs: Date.now() },
     ],
     scanStatus: 'complete',
     scanDurationMs: 100,
@@ -749,9 +749,9 @@ describe('SET_TYPE_FILTER_MODE action', () => {
 describe('TOGGLE_TYPE_FILTER action', () => {
   const baseState: AppState = {
     artifacts: [
-      { path: '/a/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: Date.now() },
-      { path: '/b/dist', type: 'dist', sizeBytes: 200, mtimeMs: Date.now() },
-      { path: '/c/.cache', type: '.cache', sizeBytes: 50, mtimeMs: Date.now() },
+      { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: Date.now() },
+      { path: '/b/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: Date.now() },
+      { path: '/c/.cache', type: '.cache', kind: 'directory', sizeBytes: 50, mtimeMs: Date.now() },
     ],
     scanStatus: 'complete',
     scanDurationMs: 100,
@@ -895,9 +895,9 @@ describe('CLEAR_TYPE_FILTER action', () => {
 describe('getSortedArtifacts with type filter', () => {
   const baseState: AppState = {
     artifacts: [
-      { path: '/a/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: 1 },
-      { path: '/b/dist', type: 'dist', sizeBytes: 200, mtimeMs: 2 },
-      { path: '/c/.cache', type: '.cache', sizeBytes: 300, mtimeMs: 3 },
+      { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: 1 },
+      { path: '/b/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: 2 },
+      { path: '/c/.cache', type: '.cache', kind: 'directory', sizeBytes: 300, mtimeMs: 3 },
     ],
     scanStatus: 'complete',
     scanDurationMs: 100,
@@ -959,8 +959,8 @@ describe('getSortedArtifacts with type filter', () => {
 describe('SET_CURSOR action', () => {
   const baseState: AppState = {
     artifacts: [
-      { path: '/a/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: Date.now() },
-      { path: '/b/dist', type: 'dist', sizeBytes: 200, mtimeMs: Date.now() },
+      { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: Date.now() },
+      { path: '/b/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: Date.now() },
     ],
     scanStatus: 'complete',
     scanDurationMs: 100,
@@ -1036,9 +1036,9 @@ describe('SET_SELECTION_ANCHOR action', () => {
 describe('cursor movement clears selectionAnchor', () => {
   const baseState: AppState = {
     artifacts: [
-      { path: '/a/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: Date.now() },
-      { path: '/b/dist', type: 'dist', sizeBytes: 200, mtimeMs: Date.now() },
-      { path: '/c/.next', type: '.next', sizeBytes: 300, mtimeMs: Date.now() },
+      { path: '/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: Date.now() },
+      { path: '/b/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: Date.now() },
+      { path: '/c/.next', type: '.next', kind: 'directory', sizeBytes: 300, mtimeMs: Date.now() },
     ],
     scanStatus: 'complete',
     scanDurationMs: 100,

--- a/src/app/reducer.test.ts
+++ b/src/app/reducer.test.ts
@@ -1178,10 +1178,11 @@ describe('getDisplayItems()', () => {
     };
     const items = getDisplayItems(state);
 
-    expect(items).toHaveLength(3); // 1 group header + 2 files
-    expect(items[0]!.kind).toBe('file-group');
-    expect(items[1]!.kind).toBe('file');
+    expect(items).toHaveLength(4); // 1 separator + 1 group header + 2 files
+    expect(items[0]!.kind).toBe('section-separator');
+    expect(items[1]!.kind).toBe('file-group');
     expect(items[2]!.kind).toBe('file');
+    expect(items[3]!.kind).toBe('file');
   });
 
   test('collapsed file group shows only header', () => {
@@ -1194,7 +1195,27 @@ describe('getDisplayItems()', () => {
     };
     const items = getDisplayItems(state);
 
-    expect(items).toHaveLength(1); // just the group header
-    expect(items[0]!.kind).toBe('file-group');
+    expect(items).toHaveLength(2); // 1 separator + the group header
+    expect(items[0]!.kind).toBe('section-separator');
+    expect(items[1]!.kind).toBe('file-group');
+  });
+
+  test('adds section separators for both directories and files', () => {
+    const state: AppState = {
+      ...initialState,
+      artifacts: [
+        { path: '/project/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 500, mtimeMs: 1000 },
+        { path: '/a/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 100, mtimeMs: 2000 },
+      ],
+    };
+    const items = getDisplayItems(state);
+    const separators = items.filter((i) => i.kind === 'section-separator');
+    expect(separators).toHaveLength(2);
+    if (separators[0]!.kind === 'section-separator') {
+      expect(separators[0]!.label).toBe('Directories');
+    }
+    if (separators[1]!.kind === 'section-separator') {
+      expect(separators[1]!.label).toBe('Files');
+    }
   });
 });

--- a/src/app/reducer.test.ts
+++ b/src/app/reducer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'bun:test';
 import { formatBytes } from '../shared/formatters.js';
 import { sizeColor, theme } from '../shared/theme.js';
-import { reducer, getSortedArtifacts } from './reducer.js';
+import { reducer, getSortedArtifacts, initialState } from './reducer.js';
 import type { AppState } from './reducer.js';
 
 // ─── Pure function tests (no Ink render required) ───────────────────────────
@@ -70,6 +70,7 @@ describe('reducer — selection', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('TOGGLE_SELECT adds a path', () => {
@@ -156,6 +157,7 @@ describe('CURSOR_HOME action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('sets cursorIndex to 0', () => {
@@ -199,6 +201,7 @@ describe('CURSOR_END action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('sets cursorIndex to last artifact', () => {
@@ -244,6 +247,7 @@ describe('SET_SEARCH_MODE action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('enables search mode', () => {
@@ -285,6 +289,7 @@ describe('SET_SEARCH_QUERY action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('updates search query', () => {
@@ -340,6 +345,7 @@ describe('DELETE_COMPLETE sets toast', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('sets deleteToast with count and freed bytes', () => {
@@ -398,6 +404,7 @@ describe('DISMISS_TOAST action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('clears deleteToast', () => {
@@ -437,6 +444,7 @@ describe('getSortedArtifacts with search filter', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('returns all artifacts when searchQuery is empty', () => {
@@ -527,6 +535,7 @@ describe('TOGGLE_GROUPING action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('enables grouping', () => {
@@ -577,6 +586,7 @@ describe('TOGGLE_GROUP_COLLAPSE action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('adds key to collapsed groups', () => {
@@ -620,6 +630,7 @@ describe('SELECT_PATHS action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('adds multiple paths to selection', () => {
@@ -666,6 +677,7 @@ describe('DESELECT_PATHS action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('removes multiple paths from selection', () => {
@@ -713,6 +725,7 @@ describe('SET_TYPE_FILTER_MODE action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('enables type filter mode', () => {
@@ -762,6 +775,7 @@ describe('TOGGLE_TYPE_FILTER action', () => {
     isTypeFilterMode: true,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('creates set excluding toggled type from null', () => {
@@ -817,6 +831,8 @@ describe('TYPE_FILTER_CURSOR_UP/DOWN actions', () => {
     typeFilter: null,
     isTypeFilterMode: true,
     typeFilterCursor: 1,
+    selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('moves cursor up', () => {
@@ -867,6 +883,7 @@ describe('CLEAR_TYPE_FILTER action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('resets typeFilter to null', () => {
@@ -904,6 +921,7 @@ describe('getSortedArtifacts with type filter', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('returns all artifacts when typeFilter is null', () => {
@@ -966,6 +984,7 @@ describe('SET_CURSOR action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('sets cursorIndex to the given index', () => {
@@ -1005,6 +1024,7 @@ describe('SET_SELECTION_ANCHOR action', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: null,
+    expandedFileTypes: new Set(),
   };
 
   it('sets selectionAnchor', () => {
@@ -1042,6 +1062,7 @@ describe('cursor movement clears selectionAnchor', () => {
     isTypeFilterMode: false,
     typeFilterCursor: 0,
     selectionAnchor: 0,
+    expandedFileTypes: new Set(),
   };
 
   it('CURSOR_UP clears selectionAnchor', () => {
@@ -1072,5 +1093,52 @@ describe('cursor movement clears selectionAnchor', () => {
   it('CURSOR_PAGE_DOWN clears selectionAnchor', () => {
     const next = reducer(baseState, { type: 'CURSOR_PAGE_DOWN', visibleCount: 5 });
     expect(next.selectionAnchor).toBeNull();
+  });
+});
+
+// ─── File type expand & group select reducer tests ──────────────────────────
+
+describe('TOGGLE_FILE_TYPE_EXPAND action', () => {
+  it('toggles file type in expandedFileTypes', () => {
+    const state = { ...initialState };
+    const next = reducer(state, { type: 'TOGGLE_FILE_TYPE_EXPAND', fileType: '.tsbuildinfo' });
+    expect(next.expandedFileTypes.has('.tsbuildinfo')).toBe(true);
+
+    const next2 = reducer(next, { type: 'TOGGLE_FILE_TYPE_EXPAND', fileType: '.tsbuildinfo' });
+    expect(next2.expandedFileTypes.has('.tsbuildinfo')).toBe(false);
+  });
+});
+
+describe('TOGGLE_FILE_GROUP_SELECT action', () => {
+  it('selects all files when none selected', () => {
+    const state: AppState = {
+      ...initialState,
+      artifacts: [
+        { path: '/a/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 100, mtimeMs: 1000 },
+        { path: '/b/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 200, mtimeMs: 2000 },
+      ],
+    };
+    const next = reducer(state, {
+      type: 'TOGGLE_FILE_GROUP_SELECT',
+      paths: ['/a/.tsbuildinfo', '/b/.tsbuildinfo'],
+    });
+    expect(next.selectedPaths.has('/a/.tsbuildinfo')).toBe(true);
+    expect(next.selectedPaths.has('/b/.tsbuildinfo')).toBe(true);
+  });
+
+  it('deselects all files when all selected', () => {
+    const state: AppState = {
+      ...initialState,
+      selectedPaths: new Set(['/a/.tsbuildinfo', '/b/.tsbuildinfo']),
+      artifacts: [
+        { path: '/a/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 100, mtimeMs: 1000 },
+        { path: '/b/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 200, mtimeMs: 2000 },
+      ],
+    };
+    const next = reducer(state, {
+      type: 'TOGGLE_FILE_GROUP_SELECT',
+      paths: ['/a/.tsbuildinfo', '/b/.tsbuildinfo'],
+    });
+    expect(next.selectedPaths.size).toBe(0);
   });
 });

--- a/src/app/reducer.test.ts
+++ b/src/app/reducer.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, test, expect } from 'bun:test';
 import { formatBytes } from '../shared/formatters.js';
 import { sizeColor, theme } from '../shared/theme.js';
-import { reducer, getSortedArtifacts, initialState } from './reducer.js';
+import { reducer, getSortedArtifacts, getDisplayItems, initialState } from './reducer.js';
 import type { AppState } from './reducer.js';
 
 // ─── Pure function tests (no Ink render required) ───────────────────────────
@@ -1140,5 +1140,61 @@ describe('TOGGLE_FILE_GROUP_SELECT action', () => {
       paths: ['/a/.tsbuildinfo', '/b/.tsbuildinfo'],
     });
     expect(next.selectedPaths.size).toBe(0);
+  });
+});
+
+// ─── getDisplayItems tests ──────────────────────────────────────────────────
+
+describe('getDisplayItems()', () => {
+  test('groups file artifacts by type', () => {
+    const state: AppState = {
+      ...initialState,
+      artifacts: [
+        { path: '/project/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 500, mtimeMs: 1000 },
+        { path: '/a/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 100, mtimeMs: 2000 },
+        { path: '/b/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 200, mtimeMs: 3000 },
+      ],
+    };
+    const items = getDisplayItems(state);
+
+    const dirItems = items.filter((i) => i.kind === 'directory');
+    const groupItems = items.filter((i) => i.kind === 'file-group');
+    expect(dirItems).toHaveLength(1);
+    expect(groupItems).toHaveLength(1);
+    if (groupItems[0]!.kind === 'file-group') {
+      expect(groupItems[0]!.group.files).toHaveLength(2);
+      expect(groupItems[0]!.group.totalSize).toBe(300);
+    }
+  });
+
+  test('expands file group when type is in expandedFileTypes', () => {
+    const state: AppState = {
+      ...initialState,
+      expandedFileTypes: new Set(['.tsbuildinfo']),
+      artifacts: [
+        { path: '/a/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 100, mtimeMs: 1000 },
+        { path: '/b/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 200, mtimeMs: 2000 },
+      ],
+    };
+    const items = getDisplayItems(state);
+
+    expect(items).toHaveLength(3); // 1 group header + 2 files
+    expect(items[0]!.kind).toBe('file-group');
+    expect(items[1]!.kind).toBe('file');
+    expect(items[2]!.kind).toBe('file');
+  });
+
+  test('collapsed file group shows only header', () => {
+    const state: AppState = {
+      ...initialState,
+      artifacts: [
+        { path: '/a/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 100, mtimeMs: 1000 },
+        { path: '/b/.tsbuildinfo', type: '.tsbuildinfo', kind: 'file', sizeBytes: 200, mtimeMs: 2000 },
+      ],
+    };
+    const items = getDisplayItems(state);
+
+    expect(items).toHaveLength(1); // just the group header
+    expect(items[0]!.kind).toBe('file-group');
   });
 });

--- a/src/app/reducer.ts
+++ b/src/app/reducer.ts
@@ -32,6 +32,7 @@ export interface AppState {
   typeFilterCursor: number;
   selectionAnchor: number | null;
   detailScrollOffset: number;
+  expandedFileTypes: Set<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -77,7 +78,9 @@ export type AppAction =
   | { type: 'SET_CURSOR'; index: number }
   | { type: 'SET_SELECTION_ANCHOR'; anchor: number }
   | { type: 'DETAIL_SCROLL_UP' }
-  | { type: 'DETAIL_SCROLL_DOWN'; totalLines: number; maxHeight: number };
+  | { type: 'DETAIL_SCROLL_DOWN'; totalLines: number; maxHeight: number }
+  | { type: 'TOGGLE_FILE_TYPE_EXPAND'; fileType: string }
+  | { type: 'TOGGLE_FILE_GROUP_SELECT'; paths: string[] };
 
 // ---------------------------------------------------------------------------
 // Reducer
@@ -115,6 +118,7 @@ export const initialState: AppState = {
   typeFilterCursor: 0,
   selectionAnchor: null,
   detailScrollOffset: 0,
+  expandedFileTypes: new Set(),
 };
 
 export function reducer(state: AppState, action: AppAction): AppState {
@@ -425,6 +429,31 @@ export function reducer(state: AppState, action: AppAction): AppState {
         ...state,
         detailScrollOffset: Math.min(maxOffset, state.detailScrollOffset + 1),
       };
+    }
+
+    case 'TOGGLE_FILE_TYPE_EXPAND': {
+      const next = new Set(state.expandedFileTypes);
+      if (next.has(action.fileType)) {
+        next.delete(action.fileType);
+      } else {
+        next.add(action.fileType);
+      }
+      return { ...state, expandedFileTypes: next };
+    }
+
+    case 'TOGGLE_FILE_GROUP_SELECT': {
+      const allSelected = action.paths.every((p) => state.selectedPaths.has(p));
+      const next = new Set(state.selectedPaths);
+      if (allSelected) {
+        for (const p of action.paths) {
+          next.delete(p);
+        }
+      } else {
+        for (const p of action.paths) {
+          next.add(p);
+        }
+      }
+      return { ...state, selectedPaths: next };
     }
 
     default: {

--- a/src/app/reducer.ts
+++ b/src/app/reducer.ts
@@ -76,6 +76,7 @@ export type AppAction =
   | { type: 'TYPE_FILTER_CURSOR_DOWN'; typeCount: number }
   | { type: 'CLEAR_TYPE_FILTER' }
   | { type: 'SET_CURSOR'; index: number }
+  | { type: 'CURSOR_MOVE'; index: number }
   | { type: 'SET_SELECTION_ANCHOR'; anchor: number }
   | { type: 'DETAIL_SCROLL_UP' }
   | { type: 'DETAIL_SCROLL_DOWN'; totalLines: number; maxHeight: number }
@@ -427,6 +428,11 @@ export function reducer(state: AppState, action: AppAction): AppState {
 
     case 'SET_CURSOR': {
       return { ...state, cursorIndex: action.index };
+    }
+
+    case 'CURSOR_MOVE': {
+      if (action.index === state.cursorIndex) return state;
+      return { ...state, cursorIndex: action.index, selectionAnchor: null, detailScrollOffset: 0 };
     }
 
     case 'SET_SELECTION_ANCHOR': {

--- a/src/app/reducer.ts
+++ b/src/app/reducer.ts
@@ -96,7 +96,8 @@ export interface FileGroup {
 export type DisplayItem =
   | { kind: 'directory'; artifact: ScanResult }
   | { kind: 'file-group'; group: FileGroup }
-  | { kind: 'file'; artifact: ScanResult; indented: boolean };
+  | { kind: 'file'; artifact: ScanResult; indented: boolean }
+  | { kind: 'section-separator'; label: string };
 
 // ---------------------------------------------------------------------------
 // Reducer
@@ -574,15 +575,21 @@ export function getDisplayItems(state: AppState): DisplayItem[] {
   // Build display items: directories first, then file groups
   const items: DisplayItem[] = [];
 
-  for (const artifact of directories) {
-    items.push({ kind: 'directory', artifact });
+  if (directories.length > 0) {
+    items.push({ kind: 'section-separator', label: 'Directories' });
+    for (const artifact of directories) {
+      items.push({ kind: 'directory', artifact });
+    }
   }
 
-  for (const group of fileGroups) {
-    items.push({ kind: 'file-group', group });
-    if (state.expandedFileTypes.has(group.type)) {
-      for (const file of group.files) {
-        items.push({ kind: 'file', artifact: file, indented: true });
+  if (fileGroups.length > 0) {
+    items.push({ kind: 'section-separator', label: 'Files' });
+    for (const group of fileGroups) {
+      items.push({ kind: 'file-group', group });
+      if (state.expandedFileTypes.has(group.type)) {
+        for (const file of group.files) {
+          items.push({ kind: 'file', artifact: file, indented: true });
+        }
       }
     }
   }

--- a/src/app/reducer.ts
+++ b/src/app/reducer.ts
@@ -83,6 +83,22 @@ export type AppAction =
   | { type: 'TOGGLE_FILE_GROUP_SELECT'; paths: string[] };
 
 // ---------------------------------------------------------------------------
+// Display items — what ArtifactTable renders
+// ---------------------------------------------------------------------------
+
+export interface FileGroup {
+  type: string;
+  files: ScanResult[];
+  totalSize: number;
+  oldestMtimeMs: number | undefined;
+}
+
+export type DisplayItem =
+  | { kind: 'directory'; artifact: ScanResult }
+  | { kind: 'file-group'; group: FileGroup }
+  | { kind: 'file'; artifact: ScanResult; indented: boolean };
+
+// ---------------------------------------------------------------------------
 // Reducer
 // ---------------------------------------------------------------------------
 
@@ -498,4 +514,78 @@ export function getSortedArtifacts(state: AppState): ScanResult[] {
   }
 
   return result;
+}
+
+/**
+ * Builds the display list: directories as individual rows, files grouped by type.
+ * File groups are collapsed by default; expanded types show individual files.
+ */
+export function getDisplayItems(state: AppState): DisplayItem[] {
+  const sorted = getSortedArtifacts(state);
+  const directories: ScanResult[] = [];
+  const filesByType = new Map<string, ScanResult[]>();
+
+  for (const artifact of sorted) {
+    if (artifact.kind === 'file') {
+      let group = filesByType.get(artifact.type);
+      if (!group) {
+        group = [];
+        filesByType.set(artifact.type, group);
+      }
+      group.push(artifact);
+    } else {
+      directories.push(artifact);
+    }
+  }
+
+  // Build file groups
+  const fileGroups: FileGroup[] = [];
+  for (const [type, files] of filesByType) {
+    let totalSize = 0;
+    let oldestMtimeMs: number | undefined;
+    for (const f of files) {
+      totalSize += f.sizeBytes ?? 0;
+      if (f.mtimeMs !== undefined) {
+        if (oldestMtimeMs === undefined || f.mtimeMs < oldestMtimeMs) {
+          oldestMtimeMs = f.mtimeMs;
+        }
+      }
+    }
+    fileGroups.push({ type, files, totalSize, oldestMtimeMs });
+  }
+
+  // Sort file groups by the same sort key as artifacts
+  fileGroups.sort((a, b) => {
+    if (state.sortKey === 'size') {
+      return state.sortDir === 'desc' ? b.totalSize - a.totalSize : a.totalSize - b.totalSize;
+    }
+    if (state.sortKey === 'path') {
+      const cmp = a.type.localeCompare(b.type);
+      return state.sortDir === 'asc' ? cmp : -cmp;
+    }
+    if (state.sortKey === 'age') {
+      const aMtime = a.oldestMtimeMs ?? 0;
+      const bMtime = b.oldestMtimeMs ?? 0;
+      return state.sortDir === 'desc' ? aMtime - bMtime : bMtime - aMtime;
+    }
+    return 0;
+  });
+
+  // Build display items: directories first, then file groups
+  const items: DisplayItem[] = [];
+
+  for (const artifact of directories) {
+    items.push({ kind: 'directory', artifact });
+  }
+
+  for (const group of fileGroups) {
+    items.push({ kind: 'file-group', group });
+    if (state.expandedFileTypes.has(group.type)) {
+      for (const file of group.files) {
+        items.push({ kind: 'file', artifact: file, indented: true });
+      }
+    }
+  }
+
+  return items;
 }

--- a/src/features/browse/ArtifactTable.tsx
+++ b/src/features/browse/ArtifactTable.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo } from 'react';
 import type { Dispatch } from 'react';
 import { Box, Text } from 'ink';
-import type { AppState, AppAction } from '../../app/reducer.js';
+import type { AppState, AppAction, DisplayItem } from '../../app/reducer.js';
 import { getSortedArtifacts } from '../../app/reducer.js';
 import { ArtifactRow } from './ArtifactRow.js';
+import { FileGroupRow } from './FileGroupRow.js';
 import { GroupRow } from './GroupRow.js';
 import { useWindow } from './useWindow.js';
 import { useTheme } from '../../shared/ThemeContext.js';
@@ -52,6 +53,7 @@ interface ArtifactTableProps {
   detailWidth?: number;
   onVisibleCountChange?: (count: number) => void;
   flatItems?: FlatItem[];
+  displayItems?: DisplayItem[];
   searchQuery?: string;
   isSearchMode?: boolean;
   searchResultCount?: number;
@@ -70,6 +72,7 @@ export function ArtifactTable({
   detailWidth = 0,
   onVisibleCountChange,
   flatItems,
+  displayItems,
   searchQuery = '',
   isSearchMode = false,
   searchResultCount = 0,
@@ -79,9 +82,11 @@ export function ArtifactTable({
   const sortedArtifacts = getSortedArtifacts(state);
   const reservedRows = (termHeight >= 30 ? RESERVED_ROWS_FULL : RESERVED_ROWS_COMPACT) + extraReservedRows;
 
-  // In grouping mode, use flat items; otherwise use sorted artifacts
+  // In grouping mode, use flat items; with display items, use those; else sorted artifacts
   const totalItemCount = state.groupingEnabled && flatItems
     ? flatItems.length
+    : displayItems
+    ? displayItems.length
     : sortedArtifacts.length;
 
   const { visibleItems: visibleFlatItems, scrollOffset, visibleCount } = useWindow<FlatItem>(
@@ -96,9 +101,23 @@ export function ArtifactTable({
     reservedRows,
   );
 
+  const { visibleItems: visibleDisplayItems, scrollOffset: displayScrollOffset, visibleCount: displayVisibleCount } = useWindow<DisplayItem>(
+    displayItems ?? [],
+    state.cursorIndex,
+    reservedRows,
+  );
+
   // Use the right values depending on mode
-  const effectiveVisibleCount = state.groupingEnabled && flatItems ? visibleCount : artVisibleCount;
-  const effectiveScrollOffset = state.groupingEnabled && flatItems ? scrollOffset : artScrollOffset;
+  const effectiveVisibleCount = state.groupingEnabled && flatItems
+    ? visibleCount
+    : displayItems
+    ? displayVisibleCount
+    : artVisibleCount;
+  const effectiveScrollOffset = state.groupingEnabled && flatItems
+    ? scrollOffset
+    : displayItems
+    ? displayScrollOffset
+    : artScrollOffset;
 
   useEffect(() => {
     onVisibleCountChange?.(effectiveVisibleCount);
@@ -208,8 +227,52 @@ export function ArtifactTable({
             </Box>
           );
         })
+      ) : displayItems ? (
+        // Display items mode: render file groups + directories
+        visibleDisplayItems.map((item, i) => {
+          const absoluteIndex = displayScrollOffset + i;
+          const key = item.kind === 'file-group'
+            ? `fgroup-${item.group.type}`
+            : item.kind === 'file'
+            ? `file-${item.artifact.path}`
+            : `dir-${item.artifact.path}`;
+
+          return (
+            <Box key={key}>
+              <Box flexGrow={1}>
+                {item.kind === 'file-group' ? (
+                  <FileGroupRow
+                    group={item.group}
+                    isExpanded={state.expandedFileTypes.has(item.group.type)}
+                    isCursor={absoluteIndex === state.cursorIndex}
+                    allSelected={item.group.files.every((f) => state.selectedPaths.has(f.path))}
+                    someSelected={item.group.files.some((f) => state.selectedPaths.has(f.path))}
+                  />
+                ) : (
+                  <Box flexGrow={1}>
+                    {item.kind === 'file' && item.indented && <Text>{'  '}</Text>}
+                    <ArtifactRow
+                      artifact={item.artifact}
+                      isCursor={absoluteIndex === state.cursorIndex}
+                      isSelected={state.selectedPaths.has(item.artifact.path)}
+                      rootPath={rootPath}
+                      maxSizeBytes={state.maxSizeBytes}
+                      commonPrefix={commonPrefix}
+                      themeName={state.themeName}
+                      pathWidth={pathWidth - (item.kind === 'file' && item.indented ? 2 : 0)}
+                      isSensitive={sensitiveSet.has(item.artifact.path)}
+                    />
+                  </Box>
+                )}
+              </Box>
+              {showScrollbar && (
+                <Text color={theme.overlay0}>{scrollbarChars[i]}</Text>
+              )}
+            </Box>
+          );
+        })
       ) : (
-        // Normal mode: render artifact rows
+        // Fallback: render artifact rows directly
         visibleArtifacts.map((artifact, i) => {
           const absoluteIndex = artScrollOffset + i;
           return (

--- a/src/features/browse/ArtifactTable.tsx
+++ b/src/features/browse/ArtifactTable.tsx
@@ -6,6 +6,7 @@ import { getSortedArtifacts } from '../../app/reducer.js';
 import { ArtifactRow } from './ArtifactRow.js';
 import { FileGroupRow } from './FileGroupRow.js';
 import { GroupRow } from './GroupRow.js';
+import { SectionSeparator } from './SectionSeparator.js';
 import { useWindow } from './useWindow.js';
 import { useTheme } from '../../shared/ThemeContext.js';
 import { TYPE_W, SIZE_W, AGE_W } from '../../shared/themes.js';
@@ -231,7 +232,9 @@ export function ArtifactTable({
         // Display items mode: render file groups + directories
         visibleDisplayItems.map((item, i) => {
           const absoluteIndex = displayScrollOffset + i;
-          const key = item.kind === 'file-group'
+          const key = item.kind === 'section-separator'
+            ? `sep-${item.label}`
+            : item.kind === 'file-group'
             ? `fgroup-${item.group.type}`
             : item.kind === 'file'
             ? `file-${item.artifact.path}`
@@ -240,7 +243,9 @@ export function ArtifactTable({
           return (
             <Box key={key}>
               <Box flexGrow={1}>
-                {item.kind === 'file-group' ? (
+                {item.kind === 'section-separator' ? (
+                  <SectionSeparator label={item.label} width={termWidth - 4 - detailWidth - scrollbarW} />
+                ) : item.kind === 'file-group' ? (
                   <FileGroupRow
                     group={item.group}
                     isExpanded={state.expandedFileTypes.has(item.group.type)}

--- a/src/features/browse/ArtifactTable.tsx
+++ b/src/features/browse/ArtifactTable.tsx
@@ -192,6 +192,10 @@ export function ArtifactTable({
           const absoluteIndex = effectiveScrollOffset + i;
           const key = item.kind === 'group-header'
             ? `group-${item.group.key}`
+            : item.kind === 'file-group-nested'
+            ? `fgn-${item.type}-${i}`
+            : item.kind === 'file-nested'
+            ? `fn-${item.artifact.path}`
             : `art-${item.artifact.path}`;
 
           return (
@@ -205,6 +209,32 @@ export function ArtifactTable({
                     allSelected={item.group.children.every((c) => state.selectedPaths.has(c.path))}
                     someSelected={item.group.children.some((c) => state.selectedPaths.has(c.path))}
                   />
+                ) : item.kind === 'file-group-nested' ? (
+                  <Box flexGrow={1}>
+                    <Text>{'  '}</Text>
+                    <FileGroupRow
+                      group={{ type: item.type, files: item.files, totalSize: item.totalSize, oldestMtimeMs: undefined }}
+                      isExpanded={state.expandedFileTypes.has(item.type)}
+                      isCursor={absoluteIndex === state.cursorIndex}
+                      allSelected={item.files.every((f) => state.selectedPaths.has(f.path))}
+                      someSelected={item.files.some((f) => state.selectedPaths.has(f.path))}
+                    />
+                  </Box>
+                ) : item.kind === 'file-nested' ? (
+                  <Box flexGrow={1}>
+                    <Text>{'    '}</Text>
+                    <ArtifactRow
+                      artifact={item.artifact}
+                      isCursor={absoluteIndex === state.cursorIndex}
+                      isSelected={state.selectedPaths.has(item.artifact.path)}
+                      rootPath={rootPath}
+                      maxSizeBytes={state.maxSizeBytes}
+                      commonPrefix={commonPrefix}
+                      themeName={state.themeName}
+                      pathWidth={pathWidth - 4}
+                      isSensitive={sensitiveSet.has(item.artifact.path)}
+                    />
+                  </Box>
                 ) : (
                   <Box flexGrow={1}>
                     {item.indented && <Text>{'  '}</Text>}

--- a/src/features/browse/DetailPanel.tsx
+++ b/src/features/browse/DetailPanel.tsx
@@ -157,7 +157,7 @@ export function DetailPanel({ artifact, width, rootPath, maxHeight, scrollOffset
     result.push(
       <Box key={k()}><Text color={theme.text}>{'Age'}</Text><Box flexGrow={1} /><Text color={ageClr}>{formatAge(artifact.mtimeMs)}</Text></Box>,
     );
-    if (itemCount !== null) {
+    if (artifact.kind !== 'file' && itemCount !== null) {
       result.push(
         <Box key={k()}><Text color={theme.text}>{'Items'}</Text><Box flexGrow={1} /><Text color={theme.flamingo}>{itemCount}</Text></Box>,
       );
@@ -184,38 +184,40 @@ export function DetailPanel({ artifact, width, rootPath, maxHeight, scrollOffset
       result.push(<Text key={k()} color={theme.green}>{'$ '}{meta.regenerate}</Text>);
     }
 
-    // Subdir chart — inline each bar as its own line element
-    result.push(<Text key={k()} color={theme.overlay0}>{sep}</Text>);
-    result.push(<Text key={k()} color={theme.text} bold>{'Largest Subdirs'}</Text>);
+    // Subdir chart — only for directory artifacts
+    if (artifact.kind !== 'file') {
+      result.push(<Text key={k()} color={theme.overlay0}>{sep}</Text>);
+      result.push(<Text key={k()} color={theme.text} bold>{'Largest Subdirs'}</Text>);
 
-    if (subdirSizes === null) {
-      result.push(<Text key={k()} color={theme.overlay0}>{'Calculating\u2026'}</Text>);
-    } else if (subdirSizes.length > 0) {
-      const segColors = SEGMENT_COLORS(theme);
-      const maxBytes = subdirSizes[0]!.bytes;
-      const sizeColW = 10; // enough for "1,024.5 MB"
-      const nameColW = 12;
-      const barWidth = Math.max(4, innerW - nameColW - sizeColW - 3); // 3 = spaces
-      for (let i = 0; i < subdirSizes.length; i++) {
-        const seg = subdirSizes[i]!;
-        const filled = Math.max(1, Math.round((seg.bytes / maxBytes) * barWidth));
-        const empty = barWidth - filled;
-        const color = segColors[i % segColors.length]!;
-        const segName = seg.name.length > nameColW ? seg.name.slice(0, nameColW - 1) + '\u2026' : seg.name;
-        const sizeStr = formatBytes(seg.bytes).padStart(sizeColW);
-        result.push(
-          <Text key={k()}>
-            <Text color={theme.text}>{segName.padEnd(nameColW)}</Text>
-            <Text>{' '}</Text>
-            <Text color={color}>{'\u2588'.repeat(filled)}</Text>
-            <Text color={theme.overlay0}>{'\u2591'.repeat(empty)}</Text>
-            <Text>{' '}</Text>
-            <Text color={theme.overlay0}>{sizeStr}</Text>
-          </Text>,
-        );
+      if (subdirSizes === null) {
+        result.push(<Text key={k()} color={theme.overlay0}>{'Calculating\u2026'}</Text>);
+      } else if (subdirSizes.length > 0) {
+        const segColors = SEGMENT_COLORS(theme);
+        const maxBytes = subdirSizes[0]!.bytes;
+        const sizeColW = 10; // enough for "1,024.5 MB"
+        const nameColW = 12;
+        const barWidth = Math.max(4, innerW - nameColW - sizeColW - 3); // 3 = spaces
+        for (let i = 0; i < subdirSizes.length; i++) {
+          const seg = subdirSizes[i]!;
+          const filled = Math.max(1, Math.round((seg.bytes / maxBytes) * barWidth));
+          const empty = barWidth - filled;
+          const color = segColors[i % segColors.length]!;
+          const segName = seg.name.length > nameColW ? seg.name.slice(0, nameColW - 1) + '\u2026' : seg.name;
+          const sizeStr = formatBytes(seg.bytes).padStart(sizeColW);
+          result.push(
+            <Text key={k()}>
+              <Text color={theme.text}>{segName.padEnd(nameColW)}</Text>
+              <Text>{' '}</Text>
+              <Text color={color}>{'\u2588'.repeat(filled)}</Text>
+              <Text color={theme.overlay0}>{'\u2591'.repeat(empty)}</Text>
+              <Text>{' '}</Text>
+              <Text color={theme.overlay0}>{sizeStr}</Text>
+            </Text>,
+          );
+        }
+      } else {
+        result.push(<Text key={k()} color={theme.overlay0}>{'Empty directory'}</Text>);
       }
-    } else {
-      result.push(<Text key={k()} color={theme.overlay0}>{'Empty directory'}</Text>);
     }
 
     return result;

--- a/src/features/browse/FileGroupRow.tsx
+++ b/src/features/browse/FileGroupRow.tsx
@@ -1,0 +1,53 @@
+import React, { memo } from 'react';
+import { Box, Text } from 'ink';
+import type { FileGroup } from '../../app/reducer.js';
+import { useTheme } from '../../shared/ThemeContext.js';
+import { SIZE_W, AGE_W } from '../../shared/themes.js';
+import { formatBytes } from '../../shared/formatters.js';
+import { BAR_WIDTH } from './SizeBar.js';
+
+// Match ArtifactRow's RIGHT_W: space + bar + space + size + space + age + space
+const RIGHT_W = 1 + BAR_WIDTH + 1 + SIZE_W + 1 + AGE_W + 1;
+
+interface FileGroupRowProps {
+  group: FileGroup;
+  isExpanded: boolean;
+  isCursor: boolean;
+  allSelected: boolean;
+  someSelected: boolean;
+}
+
+export const FileGroupRow = memo(function FileGroupRow({
+  group,
+  isExpanded,
+  isCursor,
+  allSelected,
+  someSelected,
+}: FileGroupRowProps): React.ReactElement {
+  const theme = useTheme();
+  const bg = isCursor ? theme.cursorBg : undefined;
+  const arrow = isExpanded ? '\u25BC' : '\u25B6';
+  const checkbox = allSelected ? '[x]' : (someSelected ? '[-]' : '[ ]');
+  const checkFg = isCursor ? theme.cursorFg : (allSelected ? theme.green : (someSelected ? theme.yellow : theme.overlay0));
+  const arrowFg = isCursor ? theme.cursorFg : theme.overlay0;
+  const nameFg = isCursor ? theme.cursorFg : theme.accent;
+  const infoFg = isCursor ? theme.cursorFg : theme.overlay0;
+
+  const fileCount = group.files.length;
+  const label = `${group.type} (${fileCount} file${fileCount !== 1 ? 's' : ''})`;
+
+  return (
+    <Box backgroundColor={bg} flexGrow={1}>
+      <Text color={checkFg}>{` ${checkbox} `}</Text>
+      <Text color={arrowFg}>{arrow} </Text>
+      <Text color={nameFg} bold>{label}</Text>
+      <Box flexGrow={1} />
+      <Box width={RIGHT_W} flexShrink={0}>
+        <Text color={infoFg}>
+          {formatBytes(group.totalSize).padStart(RIGHT_W - 1)}
+        </Text>
+        <Text>{' '}</Text>
+      </Box>
+    </Box>
+  );
+});

--- a/src/features/browse/SectionSeparator.tsx
+++ b/src/features/browse/SectionSeparator.tsx
@@ -1,0 +1,27 @@
+import React, { memo } from 'react';
+import { Box, Text } from 'ink';
+import { useTheme } from '../../shared/ThemeContext.js';
+
+interface SectionSeparatorProps {
+  label: string;
+  width: number;
+}
+
+export const SectionSeparator = memo(function SectionSeparator({
+  label,
+  width,
+}: SectionSeparatorProps): React.ReactElement {
+  const theme = useTheme();
+  const labelText = ` ${label} `;
+  const lineWidth = Math.max(0, width - labelText.length - 2); // 2 for leading chars
+  const leftLine = '\u2500\u2500';
+  const rightLine = '\u2500'.repeat(Math.max(0, lineWidth));
+
+  return (
+    <Box>
+      <Text color={theme.overlay0}>{leftLine}</Text>
+      <Text color={theme.overlay0} bold>{labelText}</Text>
+      <Text color={theme.overlay0}>{rightLine}</Text>
+    </Box>
+  );
+});

--- a/src/features/browse/browse.test.tsx
+++ b/src/features/browse/browse.test.tsx
@@ -15,6 +15,7 @@ describe('ArtifactRow', () => {
   const baseArtifact = {
     path: '/home/user/project/node_modules',
     type: 'node_modules',
+    kind: 'directory' as const,
     sizeBytes: null as number | null,
     mtimeMs: Date.now() - 90 * 24 * 60 * 60 * 1000,
   };
@@ -257,6 +258,7 @@ describe('DetailPanel', () => {
   const artifact = {
     path: '/home/user/projects/webapp/node_modules',
     type: 'node_modules',
+    kind: 'directory' as const,
     sizeBytes: 1340000000,
     mtimeMs: Date.now() - 92 * 24 * 60 * 60 * 1000,
   };
@@ -296,6 +298,7 @@ describe('DetailPanel sizing', () => {
   const artifact = {
     path: '/home/user/projects/webapp/node_modules',
     type: 'node_modules',
+    kind: 'directory' as const,
     sizeBytes: 1340000000,
     mtimeMs: Date.now() - 92 * 24 * 60 * 60 * 1000,
   };
@@ -403,6 +406,7 @@ describe('ArtifactRow — selection', () => {
   const artifact = {
     path: '/home/user/project/node_modules',
     type: 'node_modules',
+    kind: 'directory' as const,
     sizeBytes: 500000000,
     mtimeMs: Date.now() - 30 * 24 * 60 * 60 * 1000,
   };

--- a/src/features/browse/grouping.test.ts
+++ b/src/features/browse/grouping.test.ts
@@ -6,9 +6,9 @@ import type { ScanResult } from '../scanning/types.js';
 describe('groupArtifacts', () => {
   it('groups artifacts by parent directory', () => {
     const artifacts: ScanResult[] = [
-      { path: '/root/frontend/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: 1000 },
-      { path: '/root/frontend/dist', type: 'dist', sizeBytes: 200, mtimeMs: 2000 },
-      { path: '/root/backend/node_modules', type: 'node_modules', sizeBytes: 300, mtimeMs: 3000 },
+      { path: '/root/frontend/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: 1000 },
+      { path: '/root/frontend/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: 2000 },
+      { path: '/root/backend/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 300, mtimeMs: 3000 },
     ];
     const groups = groupArtifacts(artifacts, '/root');
     expect(groups).toHaveLength(2);
@@ -20,8 +20,8 @@ describe('groupArtifacts', () => {
 
   it('computes totalSize correctly', () => {
     const artifacts: ScanResult[] = [
-      { path: '/root/app/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: 1000 },
-      { path: '/root/app/dist', type: 'dist', sizeBytes: 200, mtimeMs: 2000 },
+      { path: '/root/app/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: 1000 },
+      { path: '/root/app/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: 2000 },
     ];
     const groups = groupArtifacts(artifacts, '/root');
     expect(groups[0]!.totalSize).toBe(300);
@@ -29,8 +29,8 @@ describe('groupArtifacts', () => {
 
   it('computes oldestMtimeMs correctly', () => {
     const artifacts: ScanResult[] = [
-      { path: '/root/app/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: 5000 },
-      { path: '/root/app/dist', type: 'dist', sizeBytes: 200, mtimeMs: 1000 },
+      { path: '/root/app/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: 5000 },
+      { path: '/root/app/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: 1000 },
     ];
     const groups = groupArtifacts(artifacts, '/root');
     expect(groups[0]!.oldestMtimeMs).toBe(1000);
@@ -38,8 +38,8 @@ describe('groupArtifacts', () => {
 
   it('handles null sizeBytes', () => {
     const artifacts: ScanResult[] = [
-      { path: '/root/app/node_modules', type: 'node_modules', sizeBytes: null, mtimeMs: 1000 },
-      { path: '/root/app/dist', type: 'dist', sizeBytes: 200, mtimeMs: 2000 },
+      { path: '/root/app/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: null, mtimeMs: 1000 },
+      { path: '/root/app/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: 2000 },
     ];
     const groups = groupArtifacts(artifacts, '/root');
     expect(groups[0]!.totalSize).toBe(200);
@@ -47,7 +47,7 @@ describe('groupArtifacts', () => {
 
   it('handles artifacts at root level', () => {
     const artifacts: ScanResult[] = [
-      { path: '/root/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: 1000 },
+      { path: '/root/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: 1000 },
     ];
     const groups = groupArtifacts(artifacts, '/root');
     expect(groups[0]!.key).toBe('.');
@@ -55,8 +55,8 @@ describe('groupArtifacts', () => {
 
   it('handles nested directories', () => {
     const artifacts: ScanResult[] = [
-      { path: '/root/infra/cdk.out/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: 1000 },
-      { path: '/root/infra/cdk.out/dist', type: 'dist', sizeBytes: 200, mtimeMs: 2000 },
+      { path: '/root/infra/cdk.out/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: 1000 },
+      { path: '/root/infra/cdk.out/dist', type: 'dist', kind: 'directory', sizeBytes: 200, mtimeMs: 2000 },
     ];
     const groups = groupArtifacts(artifacts, '/root');
     expect(groups[0]!.key).toBe('infra/cdk.out');
@@ -65,8 +65,8 @@ describe('groupArtifacts', () => {
 
   it('preserves insertion order of groups', () => {
     const artifacts: ScanResult[] = [
-      { path: '/root/b/node_modules', type: 'node_modules', sizeBytes: 100, mtimeMs: 1000 },
-      { path: '/root/a/node_modules', type: 'node_modules', sizeBytes: 200, mtimeMs: 2000 },
+      { path: '/root/b/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 100, mtimeMs: 1000 },
+      { path: '/root/a/node_modules', type: 'node_modules', kind: 'directory', sizeBytes: 200, mtimeMs: 2000 },
     ];
     const groups = groupArtifacts(artifacts, '/root');
     expect(groups[0]!.key).toBe('b');
@@ -80,6 +80,7 @@ describe('flattenGroups', () => {
     children: childPaths.map((p) => ({
       path: p,
       type: 'node_modules',
+      kind: 'directory' as const,
       sizeBytes: 100,
       mtimeMs: 1000,
     })),

--- a/src/features/browse/grouping.ts
+++ b/src/features/browse/grouping.ts
@@ -14,7 +14,9 @@ export interface ArtifactGroup {
 
 export type FlatItem =
   | { kind: 'group-header'; group: ArtifactGroup }
-  | { kind: 'artifact'; artifact: ScanResult; indented: boolean };
+  | { kind: 'artifact'; artifact: ScanResult; indented: boolean }
+  | { kind: 'file-group-nested'; type: string; files: ScanResult[]; totalSize: number; indented: boolean }
+  | { kind: 'file-nested'; artifact: ScanResult; indented: boolean };
 
 // ---------------------------------------------------------------------------
 // groupArtifacts — groups sorted artifacts by parent directory, merging
@@ -140,14 +142,41 @@ export function groupArtifacts(
 export function flattenGroups(
   groups: ArtifactGroup[],
   collapsedGroups: ReadonlySet<string>,
+  expandedFileTypes?: ReadonlySet<string>,
 ): FlatItem[] {
   const items: FlatItem[] = [];
 
   for (const group of groups) {
     items.push({ kind: 'group-header', group });
     if (!collapsedGroups.has(group.key)) {
-      for (const child of group.children) {
+      // Separate directory children from file children
+      const dirChildren = group.children.filter((c) => c.kind !== 'file');
+      const fileChildren = group.children.filter((c) => c.kind === 'file');
+
+      // Emit directory children as normal
+      for (const child of dirChildren) {
         items.push({ kind: 'artifact', artifact: child, indented: true });
+      }
+
+      // Group file children by type
+      const filesByType = new Map<string, ScanResult[]>();
+      for (const file of fileChildren) {
+        let bucket = filesByType.get(file.type);
+        if (!bucket) {
+          bucket = [];
+          filesByType.set(file.type, bucket);
+        }
+        bucket.push(file);
+      }
+
+      for (const [type, files] of filesByType) {
+        const totalSize = files.reduce((sum, f) => sum + (f.sizeBytes ?? 0), 0);
+        items.push({ kind: 'file-group-nested', type, files, totalSize, indented: true });
+        if (expandedFileTypes?.has(type)) {
+          for (const file of files) {
+            items.push({ kind: 'file-nested', artifact: file, indented: true });
+          }
+        }
       }
     }
   }

--- a/src/features/deletion/useDelete.ts
+++ b/src/features/deletion/useDelete.ts
@@ -28,7 +28,9 @@ export function useDelete(
       });
 
       try {
-        await rm(artifact.path, { recursive: true, force: true });
+        await rm(artifact.path, artifact.kind === 'directory'
+          ? { recursive: true, force: true }
+          : { force: true });
         freedBytes += artifact.sizeBytes ?? 0;
         deletedPaths.push(artifact.path);
       } catch {

--- a/src/features/scanning/constants.ts
+++ b/src/features/scanning/constants.ts
@@ -25,10 +25,6 @@ export const TARGET_DIRS: ReadonlySet<string> = new Set([
   '.rollup.cache',
   '.cache',
 
-  // Linter/formatter caches
-  '.eslintcache',
-  '.stylelintcache',
-
   // Transpiler caches
   '.swc',
 

--- a/src/features/scanning/constants.ts
+++ b/src/features/scanning/constants.ts
@@ -66,3 +66,37 @@ export const IGNORE_DIRS: ReadonlySet<string> = new Set([
   'sys',
   'dev',
 ]);
+
+/**
+ * Target files to find — individual build artifact files that can be safely deleted.
+ * Case-sensitive exact filename matching.
+ */
+export const TARGET_FILES: ReadonlySet<string> = new Set([
+  '.tsbuildinfo',
+  '.eslintcache',
+  '.stylelintcache',
+  '.pnp.cjs',
+  '.pnp.loader.mjs',
+]);
+
+/**
+ * File name prefixes to match — catches rotated log variants like npm-debug.log.0.
+ */
+export const TARGET_FILE_PREFIXES: readonly string[] = [
+  'npm-debug.log',
+  'yarn-error.log',
+  'yarn-debug.log',
+  'pnpm-debug.log',
+  '.pnpm-debug.log',
+  'lerna-debug.log',
+];
+
+/**
+ * File extension suffixes to match — profiling and build artifacts.
+ */
+export const TARGET_FILE_SUFFIXES: readonly string[] = [
+  '.heapsnapshot',
+  '.cpuprofile',
+  '.heapprofile',
+  '.tgz',
+];

--- a/src/features/scanning/constants.ts
+++ b/src/features/scanning/constants.ts
@@ -42,6 +42,9 @@ export const TARGET_DIRS: ReadonlySet<string> = new Set([
   'gatsby_cache',
   '.docusaurus',
 
+  // Serverless Framework outputs
+  '.serverless',
+
   // Runtime caches
   'deno_cache',
 

--- a/src/features/scanning/scanner.test.ts
+++ b/src/features/scanning/scanner.test.ts
@@ -291,4 +291,110 @@ describe('scan()', () => {
     expect(result.path).toBe('/project/node_modules');
     expect(result.type).toBe('node_modules');
   });
+
+  test('finds target files with kind: file', async () => {
+    vol.fromJSON({
+      '/project/.tsbuildinfo': '{}',
+      '/project/.eslintcache': '',
+      '/project/src/index.ts': 'export {};',
+    });
+
+    const results = [];
+    for await (const result of scan('/project')) {
+      results.push(result);
+    }
+
+    expect(results).toHaveLength(2);
+    const fileResults = results.filter((r) => r.kind === 'file');
+    expect(fileResults).toHaveLength(2);
+    const types = new Set(fileResults.map((r) => r.type));
+    expect(types).toContain('.tsbuildinfo');
+    expect(types).toContain('.eslintcache');
+  });
+
+  test('matches file prefixes for rotated logs', async () => {
+    vol.fromJSON({
+      '/project/npm-debug.log': 'error log',
+      '/project/npm-debug.log.0': 'old log',
+      '/project/yarn-error.log': 'yarn error',
+      '/project/src/index.ts': '',
+    });
+
+    const results = [];
+    for await (const result of scan('/project')) {
+      results.push(result);
+    }
+
+    const fileResults = results.filter((r) => r.kind === 'file');
+    expect(fileResults).toHaveLength(3);
+    expect(fileResults.every((r) => r.kind === 'file')).toBe(true);
+  });
+
+  test('matches file suffixes for profiling artifacts', async () => {
+    vol.fromJSON({
+      '/project/Heap.20240101.heapsnapshot': 'snapshot data',
+      '/project/CPU.20240101.cpuprofile': 'profile data',
+      '/project/package.tgz': 'archive',
+      '/project/src/index.ts': '',
+    });
+
+    const results = [];
+    for await (const result of scan('/project')) {
+      results.push(result);
+    }
+
+    const fileResults = results.filter((r) => r.kind === 'file');
+    expect(fileResults).toHaveLength(3);
+  });
+
+  test('directory results have kind: directory', async () => {
+    vol.fromJSON({
+      '/project/node_modules/pkg/index.js': '',
+      '/project/dist/bundle.js': '',
+    });
+
+    const results = [];
+    for await (const result of scan('/project')) {
+      results.push(result);
+    }
+
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.kind === 'directory')).toBe(true);
+  });
+
+  test('finds files inside subdirectories during traversal', async () => {
+    vol.fromJSON({
+      '/project/packages/a/.tsbuildinfo': '{}',
+      '/project/packages/b/.tsbuildinfo': '{}',
+      '/project/packages/b/node_modules/pkg/index.js': '',
+      '/project/src/index.ts': '',
+    });
+
+    const results = [];
+    for await (const result of scan('/project')) {
+      results.push(result);
+    }
+
+    const files = results.filter((r) => r.kind === 'file');
+    const dirs = results.filter((r) => r.kind === 'directory');
+    expect(files).toHaveLength(2);
+    expect(dirs).toHaveLength(1);
+    expect(dirs[0]!.type).toBe('node_modules');
+  });
+
+  test('file results have sizeBytes as null', async () => {
+    vol.fromJSON({
+      '/project/.tsbuildinfo': '{}',
+      '/project/.eslintcache': '',
+    });
+
+    const results = [];
+    for await (const result of scan('/project')) {
+      results.push(result);
+    }
+
+    for (const result of results) {
+      expect(result.sizeBytes).toBeNull();
+    }
+  });
 });

--- a/src/features/scanning/scanner.test.ts
+++ b/src/features/scanning/scanner.test.ts
@@ -312,7 +312,7 @@ describe('scan()', () => {
     expect(types).toContain('.eslintcache');
   });
 
-  test('matches file prefixes for rotated logs', async () => {
+  test('matches file prefixes for rotated logs and normalizes type', async () => {
     vol.fromJSON({
       '/project/npm-debug.log': 'error log',
       '/project/npm-debug.log.0': 'old log',
@@ -327,10 +327,13 @@ describe('scan()', () => {
 
     const fileResults = results.filter((r) => r.kind === 'file');
     expect(fileResults).toHaveLength(3);
-    expect(fileResults.every((r) => r.kind === 'file')).toBe(true);
+    // Both npm-debug.log and npm-debug.log.0 should have type "npm-debug.log"
+    const npmLogs = fileResults.filter((r) => r.type === 'npm-debug.log');
+    expect(npmLogs).toHaveLength(2);
+    expect(fileResults.some((r) => r.type === 'yarn-error.log')).toBe(true);
   });
 
-  test('matches file suffixes for profiling artifacts', async () => {
+  test('matches file suffixes for profiling artifacts and normalizes type', async () => {
     vol.fromJSON({
       '/project/Heap.20240101.heapsnapshot': 'snapshot data',
       '/project/CPU.20240101.cpuprofile': 'profile data',
@@ -345,6 +348,11 @@ describe('scan()', () => {
 
     const fileResults = results.filter((r) => r.kind === 'file');
     expect(fileResults).toHaveLength(3);
+    // Types should be the suffix pattern, not the full filename
+    const types = new Set(fileResults.map((r) => r.type));
+    expect(types).toContain('.heapsnapshot');
+    expect(types).toContain('.cpuprofile');
+    expect(types).toContain('.tgz');
   });
 
   test('directory results have kind: directory', async () => {

--- a/src/features/scanning/scanner.test.ts
+++ b/src/features/scanning/scanner.test.ts
@@ -271,6 +271,23 @@ describe('scan()', () => {
     expect(types).not.toContain('coverage');
   });
 
+  test('finds .serverless directory', async () => {
+    vol.fromJSON({
+      '/project/.serverless/cloudformation-template.json': '{}',
+      '/project/.serverless/function.zip': '',
+      '/project/handler.js': 'module.exports.hello = () => {};',
+    });
+
+    const results = [];
+    for await (const result of scan('/project')) {
+      results.push(result);
+    }
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.path).toBe('/project/.serverless');
+    expect(results[0]!.type).toBe('.serverless');
+  });
+
   test('returns ScanResult with correct shape', async () => {
     vol.fromJSON({
       '/project/node_modules/react/index.js': '',

--- a/src/features/scanning/scanner.test.ts
+++ b/src/features/scanning/scanner.test.ts
@@ -382,6 +382,40 @@ describe('scan()', () => {
     expect(dirs[0]!.type).toBe('node_modules');
   });
 
+  test('finds both directory and file artifacts in a monorepo', async () => {
+    vol.fromJSON({
+      '/monorepo/packages/a/node_modules/react/index.js': '',
+      '/monorepo/packages/a/.tsbuildinfo': '{}',
+      '/monorepo/packages/b/node_modules/lodash/index.js': '',
+      '/monorepo/packages/b/.tsbuildinfo': '{}',
+      '/monorepo/packages/b/.eslintcache': '',
+      '/monorepo/.stylelintcache': '',
+      '/monorepo/npm-debug.log': 'error',
+      '/monorepo/npm-debug.log.0': 'old error',
+      '/monorepo/src/index.ts': '',
+    });
+
+    const results = [];
+    for await (const result of scan('/monorepo')) {
+      results.push(result);
+    }
+
+    const dirs = results.filter((r) => r.kind === 'directory');
+    const files = results.filter((r) => r.kind === 'file');
+
+    expect(dirs).toHaveLength(2); // 2 node_modules
+    expect(files.length).toBeGreaterThanOrEqual(5); // 2 tsbuildinfo + 1 eslintcache + 1 stylelintcache + 2 npm-debug.log*
+
+    // Verify all results have required shape
+    for (const r of results) {
+      expect(r.path).toBeDefined();
+      expect(r.type).toBeDefined();
+      expect(r.kind).toBeDefined();
+      expect(r.sizeBytes).toBeNull();
+      expect(['file', 'directory']).toContain(r.kind);
+    }
+  });
+
   test('file results have sizeBytes as null', async () => {
     vol.fromJSON({
       '/project/.tsbuildinfo': '{}',

--- a/src/features/scanning/scanner.ts
+++ b/src/features/scanning/scanner.ts
@@ -1,7 +1,22 @@
 import { opendir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
-import { TARGET_DIRS, IGNORE_DIRS } from './constants.js';
+import { TARGET_DIRS, IGNORE_DIRS, TARGET_FILES, TARGET_FILE_PREFIXES, TARGET_FILE_SUFFIXES } from './constants.js';
 import type { ScanResult, ScanOptions } from './types.js';
+
+/**
+ * Returns true if the filename matches any target file pattern.
+ * Checks exact match, prefix match (rotated logs), and suffix match (profiling artifacts).
+ */
+function isTargetFile(name: string): boolean {
+  if (TARGET_FILES.has(name)) return true;
+  for (const prefix of TARGET_FILE_PREFIXES) {
+    if (name.startsWith(prefix)) return true;
+  }
+  for (const suffix of TARGET_FILE_SUFFIXES) {
+    if (name.endsWith(suffix)) return true;
+  }
+  return false;
+}
 
 /**
  * Returns true if the error is a permission-denied error (EACCES or EPERM).
@@ -15,15 +30,14 @@ function isPermissionError(err: unknown): boolean {
 }
 
 /**
- * BFS directory scanner that yields artifact directories as they are found.
+ * BFS scanner that yields artifact directories and files as they are found.
  *
  * Algorithm:
  * 1. Start a queue with [rootPath]
  * 2. Dequeue directory, open it, iterate entries
- * 3. Skip symlinks and non-directories
- * 4. Skip IGNORE_DIRS entries entirely
- * 5. If entry name is in TARGET_DIRS: yield it, do NOT recurse into it
- * 6. Otherwise: enqueue for further traversal
+ * 3. Skip symlinks
+ * 4. For files: yield if matching TARGET_FILES / prefixes / suffixes
+ * 5. For directories: skip IGNORE_DIRS, yield TARGET_DIRS, otherwise enqueue
  *
  * Key properties:
  * - Skips children of matched directories (avoids redundant traversal)
@@ -77,6 +91,28 @@ export async function* scan(
         }
 
         if (!entry.isDirectory()) {
+          // Check if this is a target file
+          if (entry.isFile() && isTargetFile(entry.name)) {
+            const filePath = join(currentDir, entry.name);
+            if (exclude?.has(entry.name)) {
+              continue;
+            }
+            let mtimeMs: number | undefined;
+            try {
+              const s = await stat(filePath);
+              mtimeMs = s.mtimeMs;
+            } catch {
+              // stat failed — leave mtimeMs undefined
+            }
+            debug?.(`scan: file artifact found ${filePath} (${entry.name})`);
+            yield {
+              path: filePath,
+              type: entry.name,
+              kind: 'file',
+              sizeBytes: null,
+              mtimeMs,
+            };
+          }
           continue;
         }
 
@@ -104,6 +140,7 @@ export async function* scan(
           yield {
             path: entryPath,
             type: entry.name,
+            kind: 'directory',
             sizeBytes: null,
             mtimeMs,
           };

--- a/src/features/scanning/scanner.ts
+++ b/src/features/scanning/scanner.ts
@@ -4,18 +4,21 @@ import { TARGET_DIRS, IGNORE_DIRS, TARGET_FILES, TARGET_FILE_PREFIXES, TARGET_FI
 import type { ScanResult, ScanOptions } from './types.js';
 
 /**
- * Returns true if the filename matches any target file pattern.
- * Checks exact match, prefix match (rotated logs), and suffix match (profiling artifacts).
+ * Returns the normalized type for a target file, or null if not a target.
+ * For exact matches, returns the filename.
+ * For prefix matches (rotated logs), returns the prefix (e.g. "npm-debug.log").
+ * For suffix matches (profiling), returns the suffix (e.g. ".heapsnapshot").
+ * This ensures files are grouped by their base type, not by exact filename.
  */
-function isTargetFile(name: string): boolean {
-  if (TARGET_FILES.has(name)) return true;
+function matchTargetFile(name: string): string | null {
+  if (TARGET_FILES.has(name)) return name;
   for (const prefix of TARGET_FILE_PREFIXES) {
-    if (name.startsWith(prefix)) return true;
+    if (name.startsWith(prefix)) return prefix;
   }
   for (const suffix of TARGET_FILE_SUFFIXES) {
-    if (name.endsWith(suffix)) return true;
+    if (name.endsWith(suffix)) return suffix;
   }
-  return false;
+  return null;
 }
 
 /**
@@ -92,26 +95,29 @@ export async function* scan(
 
         if (!entry.isDirectory()) {
           // Only scan for files when using default targets (not custom targets)
-          if (!options?.targets && entry.isFile() && isTargetFile(entry.name)) {
-            const filePath = join(currentDir, entry.name);
-            if (exclude?.has(entry.name)) {
-              continue;
+          if (!options?.targets && entry.isFile()) {
+            const fileType = matchTargetFile(entry.name);
+            if (fileType !== null) {
+              const filePath = join(currentDir, entry.name);
+              if (exclude?.has(fileType)) {
+                continue;
+              }
+              let mtimeMs: number | undefined;
+              try {
+                const s = await stat(filePath);
+                mtimeMs = s.mtimeMs;
+              } catch {
+                // stat failed — leave mtimeMs undefined
+              }
+              debug?.(`scan: file artifact found ${filePath} (${fileType})`);
+              yield {
+                path: filePath,
+                type: fileType,
+                kind: 'file',
+                sizeBytes: null,
+                mtimeMs,
+              };
             }
-            let mtimeMs: number | undefined;
-            try {
-              const s = await stat(filePath);
-              mtimeMs = s.mtimeMs;
-            } catch {
-              // stat failed — leave mtimeMs undefined
-            }
-            debug?.(`scan: file artifact found ${filePath} (${entry.name})`);
-            yield {
-              path: filePath,
-              type: entry.name,
-              kind: 'file',
-              sizeBytes: null,
-              mtimeMs,
-            };
           }
           continue;
         }

--- a/src/features/scanning/scanner.ts
+++ b/src/features/scanning/scanner.ts
@@ -91,8 +91,8 @@ export async function* scan(
         }
 
         if (!entry.isDirectory()) {
-          // Check if this is a target file
-          if (entry.isFile() && isTargetFile(entry.name)) {
+          // Only scan for files when using default targets (not custom targets)
+          if (!options?.targets && entry.isFile() && isTargetFile(entry.name)) {
             const filePath = join(currentDir, entry.name);
             if (exclude?.has(entry.name)) {
               continue;

--- a/src/features/scanning/types.ts
+++ b/src/features/scanning/types.ts
@@ -1,6 +1,7 @@
 export interface ScanResult {
   path: string;
-  type: string;           // basename of the matched dir (e.g. "node_modules", ".next")
+  type: string;           // basename of the matched dir or file (e.g. "node_modules", ".tsbuildinfo")
+  kind: 'file' | 'directory'; // whether this is a file or directory artifact
   sizeBytes: number | null; // null = not yet calculated
   mtimeMs?: number;       // last-modified time in milliseconds; undefined if stat failed
 }

--- a/src/features/scanning/useScan.ts
+++ b/src/features/scanning/useScan.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useTransition } from 'react';
 import type { Dispatch } from 'react';
 import { resolve } from 'node:path';
+import { stat } from 'node:fs/promises';
 import { scan } from './scanner.js';
 import { calculateSizeWithTimeout } from './size.js';
 import { createDebugLogger } from '../../shared/debug.js';
@@ -58,11 +59,15 @@ export function useScan(
         });
 
         const sizeStartMs = Date.now();
-        const p = calculateSizeWithTimeout(artifact.path, 30_000).then((sizeBytes) => {
+        const sizePromise = artifact.kind === 'file'
+          ? stat(artifact.path).then((s) => s.size).catch(() => 0)
+          : calculateSizeWithTimeout(artifact.path, 30_000).then((s) => s ?? 0);
+
+        const p = sizePromise.then((sizeBytes) => {
           if (!controller.signal.aborted) {
-            logger?.log(`size: ${artifact.path} → ${sizeBytes ?? 0} bytes (${Date.now() - sizeStartMs}ms)`);
+            logger?.log(`size: ${artifact.path} → ${sizeBytes} bytes (${Date.now() - sizeStartMs}ms)`);
             startTransition(() => {
-              dispatch({ type: 'SIZE_RESOLVED', path: artifact.path, sizeBytes: sizeBytes ?? 0 });
+              dispatch({ type: 'SIZE_RESOLVED', path: artifact.path, sizeBytes });
             });
           }
         }).catch((err: unknown) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { scan } from './features/scanning/scanner.js';
 export { calculateSize, calculateSizeWithTimeout } from './features/scanning/size.js';
+export { TARGET_DIRS, TARGET_FILES, TARGET_FILE_PREFIXES, TARGET_FILE_SUFFIXES } from './features/scanning/constants.js';
 export type { ScanResult, ScanOptions, ScanStats } from './features/scanning/types.js';

--- a/src/shared/artifactMeta.ts
+++ b/src/shared/artifactMeta.ts
@@ -54,8 +54,44 @@ const META_MAP: Record<string, ArtifactMeta> = {
   'dist': { description: 'Build output', regenerate: 'npm run build' },
   'build': { description: 'Build output', regenerate: 'npm run build' },
   '.output': { description: 'Build output', regenerate: 'npm run build' },
+
+  // File-based artifacts — build/compiler output
+  '.tsbuildinfo': { description: 'TypeScript incremental build info', regenerate: 'tsc --build' },
+
+  // File-based artifacts — Yarn PnP
+  '.pnp.cjs': { description: 'Yarn PnP runtime', regenerate: 'yarn install' },
+  '.pnp.loader.mjs': { description: 'Yarn PnP ESM loader', regenerate: 'yarn install' },
+
+  // File-based artifacts — package manager logs
+  'npm-debug.log': { description: 'npm debug log', regenerate: 'Not regenerated' },
+  'yarn-error.log': { description: 'Yarn error log', regenerate: 'Not regenerated' },
+  'yarn-debug.log': { description: 'Yarn debug log', regenerate: 'Not regenerated' },
+  'pnpm-debug.log': { description: 'pnpm debug log', regenerate: 'Not regenerated' },
+  '.pnpm-debug.log': { description: 'pnpm debug log', regenerate: 'Not regenerated' },
+  'lerna-debug.log': { description: 'Lerna debug log', regenerate: 'Not regenerated' },
+
+  // File-based artifacts — profiling/diagnostics
+  '.heapsnapshot': { description: 'V8 heap snapshot', regenerate: 'Not regenerated' },
+  '.cpuprofile': { description: 'V8 CPU profile', regenerate: 'Not regenerated' },
+  '.heapprofile': { description: 'V8 heap profile', regenerate: 'Not regenerated' },
+
+  // File-based artifacts — package archives
+  '.tgz': { description: 'Package archive', regenerate: 'npm pack' },
 };
 
 export function getArtifactMeta(type: string): ArtifactMeta | undefined {
-  return META_MAP[type];
+  const direct = META_MAP[type];
+  if (direct) return direct;
+
+  // Check prefix matches (rotated logs: "npm-debug.log.0" → "npm-debug.log")
+  for (const key of Object.keys(META_MAP)) {
+    if (type.startsWith(key) && type !== key) return META_MAP[key];
+  }
+
+  // Check suffix matches (profiling: "Heap.20240101.heapsnapshot" → ".heapsnapshot")
+  for (const key of Object.keys(META_MAP)) {
+    if (key.startsWith('.') && type.endsWith(key)) return META_MAP[key];
+  }
+
+  return undefined;
 }

--- a/src/shared/artifactMeta.ts
+++ b/src/shared/artifactMeta.ts
@@ -47,6 +47,9 @@ const META_MAP: Record<string, ArtifactMeta> = {
   'gatsby_cache': { description: 'Gatsby build cache', regenerate: 'gatsby build' },
   '.docusaurus': { description: 'Docusaurus build cache', regenerate: 'docusaurus build' },
 
+  // Serverless Framework outputs
+  '.serverless': { description: 'Serverless Framework deployment artifacts', regenerate: 'serverless package' },
+
   // Runtime caches
   'deno_cache': { description: 'Deno module cache', regenerate: 'Auto-regenerated on run' },
 


### PR DESCRIPTION
## Summary

Release 1.1.0 introduces file-based artifact scanning — dustoff now detects individual build artifact files alongside directories, grouped by type into collapsible rows.

### New features

- **File artifact scanning** — detects `.tsbuildinfo`, `.eslintcache`, `.stylelintcache`, `.pnp.cjs`, `.pnp.loader.mjs`, log files (`npm-debug.log*`, `yarn-error.log*`, etc.), profiling artifacts (`*.heapsnapshot`, `*.cpuprofile`, `*.heapprofile`), and package archives (`*.tgz`)
- **Grouped file rows** — multiple files of the same type collapse into a single row (e.g., `.tsbuildinfo (4 files) — 12 B`), expandable with Enter/arrows
- **Section separators** — visual dividers between Directories and Files sections in normal mode
- **Nested file groups in grouping mode** — when directory grouping (`x`) is active, file groups nest inside their parent directory groups
- **Selective file deletion** — expand a group to cherry-pick individual files, or select the whole group at once

### Technical changes

- `ScanResult` gains `kind: 'file' | 'directory'` discriminant
- New constants: `TARGET_FILES`, `TARGET_FILE_PREFIXES`, `TARGET_FILE_SUFFIXES`
- File size uses `stat()` instead of recursive traversal
- File deletion uses non-recursive `rm`
- `DisplayItem` type system for table rendering with section separators
- `FileGroupRow` and `SectionSeparator` components
- `FlatItem` extended with `file-group-nested` and `file-nested` for grouping mode
- `CURSOR_MOVE` action for navigation with proper state cleanup

Closes #11

## Test plan

- [x] Scanner detects file artifacts (exact, prefix, suffix matching)
- [x] File groups display correctly in normal mode with section separators
- [x] Cursor skips separators in both directions
- [x] Enter/arrows expand/collapse file groups
- [x] Space selects/deselects file groups and individual files
- [x] Directory grouping mode nests file groups inside directory groups
- [x] Search and type filter work across both directories and files
- [x] Deletion works for file artifacts
- [x] Files-only directories display correctly
- [x] Custom `targets` option suppresses file scanning
- [x] Empty list edge cases handled