### PR TITLE
feat: detect additional artifact directories

### DIFF
--- a/src/features/scanning/constants.ts
+++ b/src/features/scanning/constants.ts
@@ -1,6 +1,6 @@
 /**
- * Target directories to find — JS/TS artifact directories that can be safely deleted.
- * Comprehensive list of JS/TS artifact directories.
+ * Target directories to find — project artifact directories that can be safely deleted.
+ * Comprehensive list of generated artifact directories.
  * Case-sensitive exact basename matching.
  */
 export const TARGET_DIRS: ReadonlySet<string> = new Set([
@@ -8,17 +8,20 @@ export const TARGET_DIRS: ReadonlySet<string> = new Set([
   'node_modules',
   '.npm',
   '.pnpm-store',
+  '.gradle',
 
   // Framework build outputs
   '.next',
   '.nuxt',
   '.angular',
+  '.expo',
   '.svelte-kit',
   '.vite',
   '.turbo',
   '.nx',
 
   // Bundler caches
+  '.webpack',
   '.parcel-cache',
   '.rpt2_cache',
   '.esbuild',
@@ -48,6 +51,15 @@ export const TARGET_DIRS: ReadonlySet<string> = new Set([
   'dist',
   'build',
   '.output',
+]);
+
+/**
+ * Nested target directories to find where matching by basename would be unsafe
+ * or too broad. Paths use forward slashes and can appear anywhere under the
+ * scan root.
+ */
+export const TARGET_DIR_PATHS: ReadonlySet<string> = new Set([
+  '.meteor/local',
 ]);
 
 /**

--- a/src/features/scanning/scanner.test.ts
+++ b/src/features/scanning/scanner.test.ts
@@ -1,5 +1,5 @@
 import { vol } from 'memfs';
-import { mock, beforeEach, describe, test, expect } from 'bun:test';
+import { mock, afterAll, beforeEach, describe, test, expect } from 'bun:test';
 import { scan } from './scanner.js';
 
 mock.module('node:fs', () => {
@@ -13,6 +13,10 @@ mock.module('node:fs/promises', () => {
 
 beforeEach(() => {
   vol.reset();
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe('scan()', () => {
@@ -70,6 +74,33 @@ describe('scan()', () => {
     expect(foundTypes).toContain('.nuxt');
     expect(foundTypes).toContain('.parcel-cache');
     expect(results).toHaveLength(12);
+  });
+
+  test('finds additional project artifact directories', async () => {
+    vol.fromJSON({
+      '/project/.expo/web/cache.json': '{}',
+      '/project/.gradle/caches/modules-2/files-2.1/module.bin': '',
+      '/project/.meteor/local/build/programs/server/app.js': '',
+      '/project/.meteor/packages': 'meteor-base',
+      '/project/.webpack/cache/default-development/index.pack': '',
+      '/project/src/index.ts': 'export {};',
+    });
+
+    const results = [];
+    for await (const result of scan('/project')) {
+      results.push(result);
+    }
+
+    const foundTypes = new Set(results.map((r) => r.type));
+    expect(foundTypes).toContain('.expo');
+    expect(foundTypes).toContain('.gradle');
+    expect(foundTypes).toContain('.meteor/local');
+    expect(foundTypes).toContain('.webpack');
+    expect(foundTypes).not.toContain('.meteor');
+    expect(results).toHaveLength(4);
+
+    const meteorResult = results.find((r) => r.type === '.meteor/local');
+    expect(meteorResult!.path).toBe('/project/.meteor/local');
   });
 
   test('skips children of matched directories', async () => {

--- a/src/features/scanning/scanner.ts
+++ b/src/features/scanning/scanner.ts
@@ -1,6 +1,13 @@
 import { opendir, stat } from 'node:fs/promises';
-import { join } from 'node:path';
-import { TARGET_DIRS, IGNORE_DIRS, TARGET_FILES, TARGET_FILE_PREFIXES, TARGET_FILE_SUFFIXES } from './constants.js';
+import { join, relative } from 'node:path';
+import {
+  TARGET_DIRS,
+  TARGET_DIR_PATHS,
+  IGNORE_DIRS,
+  TARGET_FILES,
+  TARGET_FILE_PREFIXES,
+  TARGET_FILE_SUFFIXES,
+} from './constants.js';
 import type { ScanResult, ScanOptions } from './types.js';
 
 /**
@@ -17,6 +24,21 @@ function matchTargetFile(name: string): string | null {
   }
   for (const suffix of TARGET_FILE_SUFFIXES) {
     if (name.endsWith(suffix)) return suffix;
+  }
+  return null;
+}
+
+/**
+ * Returns the normalized type for a nested target directory path, or null if
+ * the path is not a target. This keeps cases like ".meteor/local" precise
+ * without marking the entire ".meteor" project metadata directory removable.
+ */
+function matchTargetDirectoryPath(rootPath: string, entryPath: string): string | null {
+  const relativePath = relative(rootPath, entryPath).replace(/\\/g, '/');
+  for (const targetPath of TARGET_DIR_PATHS) {
+    if (relativePath === targetPath || relativePath.endsWith(`/${targetPath}`)) {
+      return targetPath;
+    }
   }
   return null;
 }
@@ -40,7 +62,7 @@ function isPermissionError(err: unknown): boolean {
  * 2. Dequeue directory, open it, iterate entries
  * 3. Skip symlinks
  * 4. For files: yield if matching TARGET_FILES / prefixes / suffixes
- * 5. For directories: skip IGNORE_DIRS, yield TARGET_DIRS, otherwise enqueue
+ * 5. For directories: skip IGNORE_DIRS, yield TARGET_DIRS / TARGET_DIR_PATHS, otherwise enqueue
  *
  * Key properties:
  * - Skips children of matched directories (avoids redundant traversal)
@@ -127,6 +149,32 @@ export async function* scan(
         if (IGNORE_DIRS.has(entry.name)) {
           // Skip system/SCM directories — don't recurse
           continue;
+        }
+
+        if (!options?.targets) {
+          const pathType = matchTargetDirectoryPath(rootPath, entryPath);
+          if (pathType !== null) {
+            if (exclude?.has(pathType)) {
+              continue;
+            }
+            let mtimeMs: number | undefined;
+            try {
+              const s = await stat(entryPath);
+              mtimeMs = s.mtimeMs;
+            } catch {
+              // stat failed — leave mtimeMs undefined
+            }
+
+            debug?.(`scan: artifact found ${entryPath} (${pathType})`);
+            yield {
+              path: entryPath,
+              type: pathType,
+              kind: 'directory',
+              sizeBytes: null,
+              mtimeMs,
+            };
+            continue;
+          }
         }
 
         if (targets.has(entry.name)) {

--- a/src/features/scanning/size.test.ts
+++ b/src/features/scanning/size.test.ts
@@ -1,125 +1,119 @@
-import { vol } from 'memfs';
-import { mock, beforeEach, describe, test, expect } from 'bun:test';
+import { link, mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, test, expect } from 'bun:test';
 import { calculateSize, calculateSizeWithTimeout } from './size.js';
 
-mock.module('node:fs', () => {
-  const memfs = require('memfs');
-  return { default: memfs.fs, ...memfs.fs };
-});
-mock.module('node:fs/promises', () => {
-  const memfs = require('memfs');
-  return { default: memfs.fs.promises, ...memfs.fs.promises };
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'dustoff-size-test-'));
 });
 
-beforeEach(() => {
-  vol.reset();
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
 });
+
+function pathInTmp(...segments: string[]): string {
+  return join(tmpDir, ...segments);
+}
+
+const testWithHardlinks = process.platform === 'win32' ? test.skip : test;
 
 describe('calculateSize()', () => {
   test('calculates size of directory with files', async () => {
-    vol.fromJSON({
-      '/dir/a.txt': 'hello',
-      '/dir/b.txt': 'world',
-    });
+    const dir = pathInTmp('dir');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'a.txt'), 'hello');
+    await writeFile(join(dir, 'b.txt'), 'world');
 
-    const size = await calculateSize('/dir');
+    const size = await calculateSize(dir);
 
-    // memfs does not set stat.blocks accurately (typically 0), so the code falls back
-    // to stat.size. The total should be >= sum of file content lengths (5 + 5 = 10).
     expect(typeof size).toBe('number');
     expect(size).toBeGreaterThanOrEqual(10);
   });
 
   test('returns 0 for empty directory', async () => {
-    vol.mkdirSync('/empty');
+    const dir = pathInTmp('empty');
+    await mkdir(dir);
 
-    const size = await calculateSize('/empty');
+    const size = await calculateSize(dir);
 
     expect(size).toBe(0);
   });
 
   test('handles nested directories — includes all files', async () => {
-    vol.fromJSON({
-      '/root/a.txt': 'aaaa',
-      '/root/sub/b.txt': 'bbbb',
-      '/root/sub/deep/c.txt': 'cccc',
-    });
+    const root = pathInTmp('root');
+    await mkdir(join(root, 'sub', 'deep'), { recursive: true });
+    await writeFile(join(root, 'a.txt'), 'aaaa');
+    await writeFile(join(root, 'sub', 'b.txt'), 'bbbb');
+    await writeFile(join(root, 'sub', 'deep', 'c.txt'), 'cccc');
 
-    const size = await calculateSize('/root');
+    const size = await calculateSize(root);
 
-    // Each file is 4 bytes; total should be >= 12 (fallback to stat.size)
     expect(size).toBeGreaterThanOrEqual(12);
   });
 
   test('returns 0 for non-existent directory — does not throw', async () => {
-    const size = await calculateSize('/does-not-exist');
+    const size = await calculateSize(pathInTmp('does-not-exist'));
 
     expect(size).toBe(0);
   });
 
-  test('handles permission errors gracefully — still calculates accessible files', async () => {
-    // Create a directory with some accessible files
-    vol.fromJSON({
-      '/root/accessible/file.txt': 'content here',
-    });
+  test('handles accessible directories without throwing', async () => {
+    const root = pathInTmp('root');
+    await mkdir(join(root, 'accessible'), { recursive: true });
+    await writeFile(join(root, 'accessible', 'file.txt'), 'content here');
 
-    // calculateSize should not throw even if some paths fail to open
-    // The function wraps errors and returns 0 for inaccessible entries
-    const size = await calculateSize('/root');
+    const size = await calculateSize(root);
 
     expect(typeof size).toBe('number');
     expect(size).toBeGreaterThanOrEqual(0);
   });
 
-  test('deduplicates inodes — skips files with same inode key', async () => {
-    // memfs stat returns ino:0 for all files (no real hardlink support), so both
-    // files will share the same inode key "0:0". This tests the dedup code path
-    // in the context of memfs's limitations.
-    vol.fromJSON({
-      '/dir/file1.txt': 'content of file one',
-      '/dir/file2.txt': 'content of file two',
-    });
+  testWithHardlinks('deduplicates hardlinked files by inode', async () => {
+    const dir = pathInTmp('dir');
+    await mkdir(dir, { recursive: true });
+    const original = join(dir, 'file1.txt');
+    const hardlink = join(dir, 'file2.txt');
+    await writeFile(original, 'content of file one');
+    await link(original, hardlink);
 
-    const size = await calculateSize('/dir');
+    const size = await calculateSize(dir);
+    const originalStat = await stat(original);
+    const singleFileSize = originalStat.blocks != null && originalStat.blocks > 0
+      ? originalStat.blocks * 512
+      : originalStat.size;
 
-    // With real hardlinks the result would be 1x file size. With memfs, all files
-    // return ino=0, so only the first file's size is counted.
-    // We just verify the result is a non-negative number and does not throw.
     expect(typeof size).toBe('number');
-    expect(size).toBeGreaterThanOrEqual(0);
+    expect(size).toBeGreaterThan(0);
+    expect(size).toBeLessThanOrEqual(singleFileSize + 512);
   });
 });
 
 describe('calculateSizeWithTimeout()', () => {
   test('returns size for fast calculation', async () => {
-    vol.fromJSON({
-      '/dir/file.txt': 'small content',
-    });
+    const dir = pathInTmp('dir');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'file.txt'), 'small content');
 
-    const size = await calculateSizeWithTimeout('/dir', 5000);
+    const size = await calculateSizeWithTimeout(dir, 5000);
 
     expect(typeof size).toBe('number');
     expect(size).toBeGreaterThanOrEqual(0);
   });
 
   test('returns null on timeout', async () => {
-    // Use a very short timeout (1ms) so the timeout fires before the async walk completes.
-    // We need a somewhat real directory to walk — memfs is fast so we use a deep structure
-    // to give the timeout a chance to fire.
-    vol.fromJSON({
-      '/big/a/file.txt': 'x'.repeat(100),
-      '/big/b/file.txt': 'x'.repeat(100),
-      '/big/c/file.txt': 'x'.repeat(100),
-    });
+    const big = pathInTmp('big');
+    await mkdir(join(big, 'a'), { recursive: true });
+    await mkdir(join(big, 'b'), { recursive: true });
+    await mkdir(join(big, 'c'), { recursive: true });
+    await writeFile(join(big, 'a', 'file.txt'), 'x'.repeat(100));
+    await writeFile(join(big, 'b', 'file.txt'), 'x'.repeat(100));
+    await writeFile(join(big, 'c', 'file.txt'), 'x'.repeat(100));
 
-    // With timeoutMs=0, the delay fires immediately before the promise resolves.
-    // This is guaranteed because delay(0) schedules a macrotask whereas
-    // calculateSize also uses async I/O — in this controlled test the race resolves
-    // to the timeout sentinel.
-    const size = await calculateSizeWithTimeout('/big', 0);
+    const size = await calculateSizeWithTimeout(big, 0);
 
-    // May be null (timeout fired) or a number (calculation completed first).
-    // Either is valid — the important thing is it does NOT throw.
     expect(size === null || typeof size === 'number').toBe(true);
   });
 });

--- a/src/features/scanning/size.ts
+++ b/src/features/scanning/size.ts
@@ -63,6 +63,9 @@ async function sumDir(dirPath: string, seenInodes: Set<string>): Promise<number>
         }
       }
     }
+  } catch {
+    // Directory became inaccessible or disappeared during iteration.
+    return total;
   } finally {
     try {
       await dir.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
 export { scan } from './features/scanning/scanner.js';
 export { calculateSize, calculateSizeWithTimeout } from './features/scanning/size.js';
-export { TARGET_DIRS, TARGET_FILES, TARGET_FILE_PREFIXES, TARGET_FILE_SUFFIXES } from './features/scanning/constants.js';
+export {
+  TARGET_DIRS,
+  TARGET_DIR_PATHS,
+  TARGET_FILES,
+  TARGET_FILE_PREFIXES,
+  TARGET_FILE_SUFFIXES,
+} from './features/scanning/constants.js';
 export type { ScanResult, ScanOptions, ScanStats } from './features/scanning/types.js';

--- a/src/shared/artifactMeta.ts
+++ b/src/shared/artifactMeta.ts
@@ -1,6 +1,6 @@
 /**
  * Static metadata for artifact types — description and regeneration command.
- * Covers all TARGET_DIRS from constants.ts.
+ * Covers all directory and file artifact types from constants.ts.
  */
 
 interface ArtifactMeta {
@@ -13,17 +13,21 @@ const META_MAP: Record<string, ArtifactMeta> = {
   'node_modules': { description: 'Package dependencies', regenerate: 'npm install' },
   '.npm': { description: 'npm download cache', regenerate: 'npm install' },
   '.pnpm-store': { description: 'pnpm content-addressable store', regenerate: 'pnpm install' },
+  '.gradle': { description: 'Gradle build cache', regenerate: 'gradle build' },
 
   // Framework build outputs
   '.next': { description: 'Next.js build cache', regenerate: 'next build' },
   '.nuxt': { description: 'Nuxt.js build cache', regenerate: 'nuxt build' },
   '.angular': { description: 'Angular build cache', regenerate: 'ng build' },
+  '.expo': { description: 'Expo local project cache', regenerate: 'expo start' },
+  '.meteor/local': { description: 'Meteor local build cache', regenerate: 'meteor run' },
   '.svelte-kit': { description: 'SvelteKit build output', regenerate: 'svelte-kit build' },
   '.vite': { description: 'Vite dependency cache', regenerate: 'vite build' },
   '.turbo': { description: 'Turborepo build cache', regenerate: 'turbo run build' },
   '.nx': { description: 'Nx computation cache', regenerate: 'nx run build' },
 
   // Bundler caches
+  '.webpack': { description: 'Webpack filesystem cache', regenerate: 'webpack build' },
   '.parcel-cache': { description: 'Parcel bundler cache', regenerate: 'parcel build' },
   '.rpt2_cache': { description: 'Rollup TypeScript cache', regenerate: 'Auto-regenerated on build' },
   '.esbuild': { description: 'esbuild cache', regenerate: 'Auto-regenerated on build' },


### PR DESCRIPTION
## Summary
- add detection metadata for `.expo`, `.gradle`, and `.webpack` artifact directories
- add exact nested target support for `.meteor/local` so Meteor build cache is detected without marking the whole `.meteor` project metadata directory disposable
- cover the new artifact targets in scanner tests
- make `calculateSize()` tolerate directory iteration failures and update the size tests to use the real filesystem so full test runs do not leak `memfs` mocks into integration tests

Closes #5.
Closes #6.
Closes #7.
Closes #8.

## Validation
- `bun install --ignore-scripts --frozen-lockfile`
- `bun test`
- `bun run typecheck`
- `bun run build`
- `git diff --check`

This PR was prepared with AI assistance and reviewed against the current scanner and deletion paths.
